### PR TITLE
RSWEB-9355-1: Add capture utilities and response classes.

### DIFF
--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -22,6 +22,15 @@ web_page_archive.web_page_archive.*:
     capture_html:
       type: boolean
       label: 'Capture HTML'
+    capture_utilities:
+      type: sequence
+      sequence:
+        type: mapping
+        mapping:
+          uuid:
+            type: string
+          id:
+            type: string
     runs:
       type: sequence
       sequence:

--- a/src/Annotation/CaptureUtility.php
+++ b/src/Annotation/CaptureUtility.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\web_page_archive\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Capture utility item annotation object.
+ *
+ * @see \Drupal\web_page_archive\Plugin\CaptureUtilityManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class CaptureUtility extends Plugin {
+
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+}

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -194,6 +194,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
 
     return FALSE;
   }
+
   /**
    * Deletes a capture utility by id.
    *
@@ -211,6 +212,35 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
   }
 
   /**
+   * Queues the archive to run.
+   */
+  public function queueRun() {
+    // TODO: Interact with state api to indicate running status.
+    // TODO: Setup XML parsing.
+    $sitemap = [
+      'http://www.rackspace.com',
+      'http://www.rackspace.com/managed-hosting',
+    ];
+
+    foreach ($sitemap as $url) {
+      // TODO: Send to Queue API instead.
+      $this->captureUrl($url);
+    }
+  }
+
+  /**
+   * Captures and stores the specified URL results.
+   */
+  public function captureUrl($url) {
+    foreach ($this->getCaptureUtilities() as $utility) {
+      // TODO: Throw and handle exceptions.
+      $capture_response = $utility->captureUrl($url)->getResponse();
+
+      // TODO: Store result: $capture_response->getSerialized().
+    }
+  }
+
+  /**
    * Wraps the search plugin manager.
    *
    * @return \Drupal\Component\Plugin\PluginManagerInterface
@@ -219,4 +249,5 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
   protected function captureUtilityPluginManager() {
     return \Drupal::service('plugin.manager.capture_utility');
   }
+
 }

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -175,7 +175,6 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
    */
   public function deleteCaptureUtility(CaptureUtilityInterface $capture_utility) {
     $this->getCaptureUtilities()->removeInstanceId($capture_utility->getUuid());
-    $this->save();
     return $this;
   }
 
@@ -207,7 +206,6 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
         $this->getCaptureUtilities()->removeInstanceId($utility['uuid']);
       }
     }
-    $this->save();
     return $this;
   }
 
@@ -238,6 +236,34 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
 
       // TODO: Store result: $capture_response->getSerialized().
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save() {
+    // TODO: Handle this nonsense in plugins instead (future task).
+    $plugin_options = [
+      [
+        'id' => 'HtmlCaptureUtility',
+        'isCapturing' => $this->isHtmlCapturing(),
+      ],
+      [
+        'id' => 'ScreenshotCaptureUtility',
+        'isCapturing' => $this->isScreenshotCapturing(),
+      ],
+    ];
+
+    foreach ($plugin_options as $option) {
+      if (!$this->hasCaptureUtilityInstance($option['id']) && $option['isCapturing']) {
+        $this->addCaptureUtility(['id' => $option['id']]);
+      }
+      elseif (!$option['isCapturing']) {
+        $this->deleteCaptureUtilityById($option['id']);
+      }
+    }
+
+    return parent::save();
   }
 
   /**

--- a/src/Entity/WebPageArchiveInterface.php
+++ b/src/Entity/WebPageArchiveInterface.php
@@ -3,11 +3,51 @@
 namespace Drupal\web_page_archive\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\web_page_archive\Plugin\CaptureUtilityInterface;
 
 /**
  * Provides an interface for defining Web page archive entity entities.
  */
 interface WebPageArchiveInterface extends ConfigEntityInterface {
 
-  // Add get/set methods for your configuration properties here.
+  /**
+   * Returns a specific capture utility.
+   *
+   * @param string $capture_utility
+   *   The capture utility ID.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CaptureUtilityInterface
+   *   The capture utility object.
+   */
+  public function getCaptureUtility($capture_utility);
+
+  /**
+   * Returns the capture utilities for this archive.
+   *
+   * @return \Drupal\Core\Plugin\DefaultLazyPluginCollection|\Drupal\web_page_archive\Plugin\CaptureUtilityInterface[]
+   *   The capture utility plugin collection.
+   */
+  public function getCaptureUtilities();
+
+  /**
+   * Saves a capture utility for this archive.
+   *
+   * @param array $configuration
+   *   An array of capture utility configuration.
+   *
+   * @return string
+   *   The capture utility ID.
+   */
+  public function addCaptureUtility(array $configuration);
+
+  /**
+   * Deletes a capture utility from this archive.
+   *
+   * @param \Drupal\web_page_archive\Plugin\CaptureUtilityInterface $capture_utility
+   *   The capture utility object.
+   *
+   * @return $this
+   */
+  public function deleteCaptureUtility(CaptureUtilityInterface $capture_utility);
+
 }

--- a/src/Form/WebPageArchiveForm.php
+++ b/src/Form/WebPageArchiveForm.php
@@ -54,6 +54,7 @@ class WebPageArchiveForm extends EntityForm {
       '#disabled' => TRUE,
     ];
 
+    // TODO: Make plugins inject their form fields instead (future task).
     $form['capture_screenshot'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Capture Screenshot?'),
@@ -76,6 +77,28 @@ class WebPageArchiveForm extends EntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $web_page_archive = $this->entity;
+
+    // TODO: Handle this nonsense in plugins instead (future task).
+    $plugin_options = [
+      [
+        'id' => 'HtmlCaptureUtility',
+        'isCapturing' => $web_page_archive->isHtmlCapturing(),
+      ],
+      [
+        'id' => 'ScreenshotCaptureUtility',
+        'isCapturing' => $web_page_archive->isScreenshotCapturing(),
+      ],
+    ];
+
+    foreach ($plugin_options as $option) {
+      if (!$web_page_archive->hasCaptureUtilityInstance($option['id']) && $option['isCapturing']) {
+        $web_page_archive->addCaptureUtility(['id' => $option['id']]);
+      }
+      elseif (!$option['isCapturing']) {
+        $web_page_archive->deleteCaptureUtilityById($option['id']);
+      }
+    }
+
     $status = $web_page_archive->save();
 
     switch ($status) {

--- a/src/Form/WebPageArchiveForm.php
+++ b/src/Form/WebPageArchiveForm.php
@@ -78,27 +78,6 @@ class WebPageArchiveForm extends EntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $web_page_archive = $this->entity;
 
-    // TODO: Handle this nonsense in plugins instead (future task).
-    $plugin_options = [
-      [
-        'id' => 'HtmlCaptureUtility',
-        'isCapturing' => $web_page_archive->isHtmlCapturing(),
-      ],
-      [
-        'id' => 'ScreenshotCaptureUtility',
-        'isCapturing' => $web_page_archive->isScreenshotCapturing(),
-      ],
-    ];
-
-    foreach ($plugin_options as $option) {
-      if (!$web_page_archive->hasCaptureUtilityInstance($option['id']) && $option['isCapturing']) {
-        $web_page_archive->addCaptureUtility(['id' => $option['id']]);
-      }
-      elseif (!$option['isCapturing']) {
-        $web_page_archive->deleteCaptureUtilityById($option['id']);
-      }
-    }
-
     $status = $web_page_archive->save();
 
     switch ($status) {

--- a/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -16,7 +16,7 @@ class HtmlCaptureResponse extends CaptureResponseBase {
    *   The response contents.
    */
   public function __construct($content) {
-    $this->setType('html')->setContent($content);
+    $this->setType(self::TYPE_HTML)->setContent($content);
   }
 
 }

--- a/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CaptureResponse;
+
+use Drupal\web_page_archive\Plugin\CaptureResponseBase;
+
+/**
+ * Html capture response.
+ */
+class HtmlCaptureResponse extends CaptureResponseBase {
+
+  /**
+   * HtmlCaptureResponse constructor.
+   *
+   * @param string $content
+   *   The response contents.
+   */
+  public function __construct($content) {
+    $this->setType('html')->setContent($content);
+  }
+
+}

--- a/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CaptureResponse;
+
+use Drupal\web_page_archive\Plugin\CaptureResponseBase;
+
+/**
+ * Screenshot capture response.
+ */
+class ScreenshotCaptureResponse extends CaptureResponseBase {
+
+  /**
+   * ScreenshotCaptureResponse constructor.
+   *
+   * @param string $content
+   *   The response contents.
+   */
+  public function __construct($content) {
+    $this->setType('uri')->setContent($content);
+  }
+
+}

--- a/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
@@ -16,7 +16,7 @@ class ScreenshotCaptureResponse extends CaptureResponseBase {
    *   The response contents.
    */
   public function __construct($content) {
-    $this->setType('uri')->setContent($content);
+    $this->setType(self::TYPE_URI)->setContent($content);
   }
 
 }

--- a/src/Plugin/CaptureResponseBase.php
+++ b/src/Plugin/CaptureResponseBase.php
@@ -8,6 +8,16 @@ namespace Drupal\web_page_archive\Plugin;
 abstract class CaptureResponseBase implements CaptureResponseInterface {
 
   /**
+   * Response content is a URI.
+   */
+  const TYPE_URI = 'uri';
+
+  /**
+   * Response content is HTML.
+   */
+  const TYPE_HTML = 'html';
+
+  /**
    * The response content.
    *
    * @var string

--- a/src/Plugin/CaptureResponseBase.php
+++ b/src/Plugin/CaptureResponseBase.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+/**
+ * Base class for capture responses.
+ */
+abstract class CaptureResponseBase implements CaptureResponseInterface {
+
+  /**
+   * The response content.
+   *
+   * @var string
+   */
+  protected $content = '';
+
+  /**
+   * The response type.
+   *
+   * @var string
+   */
+  protected $type = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContent() {
+    return $this->content;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    return $this->type;
+  }
+
+  /**
+   * Set response content.
+   *
+   * @param string $content
+   *   The response content.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CaptureResponseInterface
+   *   Reference to self.
+   */
+  protected function setContent($content) {
+    $this->content = $content;
+
+    return $this;
+  }
+
+  /**
+   * Set response type.
+   *
+   * @param string $type
+   *   Indicates response type (e.g. 'html' or 'uri').
+   *
+   * @return \Drupal\web_page_archive\Plugin\CaptureResponseInterface
+   *   Reference to self.
+   */
+  protected function setType($type) {
+    $this->type = $type;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSerialized() {
+    return serialize([
+      'type' => $this->type,
+      'content' => $this->content,
+    ]);
+  }
+
+}

--- a/src/Plugin/CaptureResponseInterface.php
+++ b/src/Plugin/CaptureResponseInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+/**
+ * Defines an interface for Capture responses.
+ */
+interface CaptureResponseInterface {
+
+  /**
+   * Retrieve response type.
+   *
+   * @return string
+   *   String response type.
+   */
+  public function getType();
+
+  /**
+   * Retrieve content.
+   *
+   * @return string
+   *   Stringified content.
+   */
+  public function getContent();
+
+  /**
+   * Retrieve serialized representation of object.
+   *
+   * @return string
+   *   Serialized representation of object.
+   */
+  public function getSerialized();
+
+}

--- a/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CaptureUtility;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\Render\Markup;
+
+/**
+ * Captures HTML of a remote uri.
+ *
+ * @CaptureUtility(
+ *   id = "HtmlCapture",
+ *   label = @Translation("Html capture utility", context = "Web Page Archive"),
+ * )
+ */
+class HtmlCaptureUtility extends CaptureUtilityBase {
+
+  /**
+   * Most recent response.
+   *
+   * @var string|NULL
+   */
+  private $response = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function captureUrl($uri) {
+    // TODO: Do something.
+    $this->response = Markup::create('<p>Some Markup');
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResponse() {
+    return $this->response;
+  }
+
+}

--- a/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -2,14 +2,14 @@
 
 namespace Drupal\web_page_archive\Plugin\CaptureUtility;
 
-use Drupal\Component\Plugin\PluginBase;
-use Drupal\Core\Render\Markup;
+use Drupal\web_page_archive\Plugin\CaptureResponse\HtmlCaptureResponse;
+use Drupal\web_page_archive\Plugin\CaptureUtilityBase;
 
 /**
  * Captures HTML of a remote uri.
  *
  * @CaptureUtility(
- *   id = "HtmlCapture",
+ *   id = "HtmlCaptureUtility",
  *   label = @Translation("Html capture utility", context = "Web Page Archive"),
  * )
  */
@@ -26,8 +26,8 @@ class HtmlCaptureUtility extends CaptureUtilityBase {
    * {@inheritdoc}
    */
   public function captureUrl($uri) {
-    // TODO: Do something.
-    $this->response = Markup::create('<p>Some Markup');
+    // TODO: Do the actual capture.
+    $this->response = new HtmlCaptureResponse('<p>Simulated response</p>');
 
     return $this;
   }

--- a/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -18,7 +18,7 @@ class HtmlCaptureUtility extends CaptureUtilityBase {
   /**
    * Most recent response.
    *
-   * @var string|NULL
+   * @var string|null
    */
   private $response = NULL;
 

--- a/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CaptureUtility;
+
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Captures screenshot of a remote uri.
+ *
+ * @CaptureUtility(
+ *   id = "ScreenshotCapture",
+ *   label = @Translation("Screenshot capture utility", context = "Web Page Archive"),
+ * )
+ */
+class ScreenshotCaptureUtility extends CaptureUtilityBase {
+
+  /**
+   * Most recent response.
+   *
+   * @var string|null
+   */
+  private $response = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function captureUrl($uri) {
+    // TODO: Do something.
+    $this->response = NULL;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResponse() {
+    return $this->response;
+  }
+
+}

--- a/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -18,7 +18,7 @@ class ScreenshotCaptureUtility extends CaptureUtilityBase {
   /**
    * Most recent response.
    *
-   * @var string|NULL
+   * @var string|null
    */
   private $response = NULL;
 

--- a/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -2,13 +2,14 @@
 
 namespace Drupal\web_page_archive\Plugin\CaptureUtility;
 
-use Drupal\Component\Plugin\PluginBase;
+use Drupal\web_page_archive\Plugin\CaptureResponse\ScreenshotCaptureResponse;
+use Drupal\web_page_archive\Plugin\CaptureUtilityBase;
 
 /**
  * Captures screenshot of a remote uri.
  *
  * @CaptureUtility(
- *   id = "ScreenshotCapture",
+ *   id = "ScreenshotCaptureUtility",
  *   label = @Translation("Screenshot capture utility", context = "Web Page Archive"),
  * )
  */
@@ -17,7 +18,7 @@ class ScreenshotCaptureUtility extends CaptureUtilityBase {
   /**
    * Most recent response.
    *
-   * @var string|null
+   * @var string|NULL
    */
   private $response = NULL;
 
@@ -25,8 +26,8 @@ class ScreenshotCaptureUtility extends CaptureUtilityBase {
    * {@inheritdoc}
    */
   public function captureUrl($uri) {
-    // TODO: Do something.
-    $this->response = NULL;
+    // TODO: Do the actual capture.
+    $this->response = new ScreenshotCaptureResponse('https://upload.wikimedia.org/wikipedia/commons/c/c1/Drupal-wordmark.svg');
 
     return $this;
   }

--- a/src/Plugin/CaptureUtilityBase.php
+++ b/src/Plugin/CaptureUtilityBase.php
@@ -9,6 +9,4 @@ use Drupal\Component\Plugin\PluginBase;
  */
 abstract class CaptureUtilityBase extends PluginBase implements CaptureUtilityInterface {
 
-  // TODO: Add common methods and abstract methods for your plugin type here.
-
 }

--- a/src/Plugin/CaptureUtilityBase.php
+++ b/src/Plugin/CaptureUtilityBase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Base class for Capture utility plugins.
+ */
+abstract class CaptureUtilityBase extends PluginBase implements CaptureUtilityInterface {
+
+  // TODO: Add common methods and abstract methods for your plugin type here.
+
+}

--- a/src/Plugin/CaptureUtilityInterface.php
+++ b/src/Plugin/CaptureUtilityInterface.php
@@ -23,8 +23,8 @@ interface CaptureUtilityInterface extends PluginInspectionInterface {
   /**
    * Retrieves response from most recent capture.
    *
-   * @return string
-   *   A stringified response.
+   * @return Drupal\web_page_archive\Plugin\CaptureResponseInterface
+   *   A capture response object.
    */
   public function getResponse();
 

--- a/src/Plugin/CaptureUtilityInterface.php
+++ b/src/Plugin/CaptureUtilityInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for Capture utility plugins.
+ */
+interface CaptureUtilityInterface extends PluginInspectionInterface {
+
+  /**
+   * Captures the specified URL.
+   *
+   * @param string|null $url
+   *   The url to capture.
+   *
+   * @return CaptureUtilityInterface
+   *   Returns reference to self.
+   */
+  public function captureUrl($url);
+
+  /**
+   * Retrieves response from most recent capture.
+   *
+   * @return string
+   *   A stringified response.
+   */
+  public function getResponse();
+
+}

--- a/src/Plugin/CaptureUtilityManager.php
+++ b/src/Plugin/CaptureUtilityManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides the Capture utility plugin manager.
+ */
+class CaptureUtilityManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new CaptureUtilityManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/CaptureUtility', $namespaces, $module_handler, 'Drupal\web_page_archive\Plugin\CaptureUtilityInterface', 'Drupal\web_page_archive\Annotation\CaptureUtility');
+
+    $this->alterInfo('web_page_archive_capture_utility_info');
+    $this->setCacheBackend($cache_backend, 'web_page_archive_capture_utility_plugins');
+  }
+
+}

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -78,6 +78,12 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     );
     $assert->pageTextContains('Created the Test Archive Web page archive entity.');
 
+    // Verify entity has appropriate capture utilities.
+    $entity = \Drupal::entityTypeManager()->getStorage('web_page_archive')->load('test_archive');
+    $capture_utilities = $entity->getCaptureUtilities()->getConfiguration();
+    $this->assertEqual(1, count($capture_utilities));
+    $this->assertEqual('ScreenshotCaptureUtility', array_shift($capture_utilities)['id']);
+
     // Verify entity view, edit, and delete buttons are present.
     // This is to ensure the entity config is correct for user operations.
     $this->assertLinkByHref('admin/config/development/web-page-archive/test_archive');
@@ -103,6 +109,12 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     );
     $assert->pageTextContains('Saved the Test Archiver Web page archive entity.');
 
+    // Verify entity has appropriate capture utilities.
+    $entity = \Drupal::entityTypeManager()->getStorage('web_page_archive')->load('test_archive');
+    $capture_utilities = $entity->getCaptureUtilities()->getConfiguration();
+    $this->assertEqual(1, count($capture_utilities));
+    $this->assertEqual('HtmlCaptureUtility', array_shift($capture_utilities)['id']);
+
     // Verify previous values are retained.
     $this->drupalGet('admin/config/development/web-page-archive/test_archive/edit');
     $this->assertFieldByName('sitemap_url', 'http://localhost:1234/sitemap.xml');
@@ -121,7 +133,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
       'label' => 'Programmatic Archive',
       'id' => 'programmatic_archive',
       'sitemap_url' => 'http://localhost/sitemap.xml',
-      'capture_html' => FALSE,
+      'capture_html' => TRUE,
       'capture_screenshot' => TRUE,
     ];
     $wpa = \Drupal::entityManager()
@@ -136,7 +148,14 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('label', 'Programmatic Archive');
     $this->assertFieldByName('sitemap_url', 'http://localhost/sitemap.xml');
     $this->assertFieldChecked('capture_screenshot');
-    $this->assertNoFieldChecked('capture_html');
+    $this->assertFieldChecked('capture_html');
+
+    // Verify entity has appropriate capture utilities.
+    $entity = \Drupal::entityTypeManager()->getStorage('web_page_archive')->load('programmatic_archive');
+    $capture_utilities = $entity->getCaptureUtilities()->getConfiguration();
+    $this->assertEqual(2, count($capture_utilities));
+    $this->assertEqual('HtmlCaptureUtility', array_shift($capture_utilities)['id']);
+    $this->assertEqual('ScreenshotCaptureUtility', array_shift($capture_utilities)['id']);
 
   }
 

--- a/tests/src/Unit/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
+++ b/tests/src/Unit/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CaptureResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\web_page_archive\Plugin\CaptureResponse\HtmlCaptureResponse;
+
+/**
+ * @coversDefaultClass \Drupal\web_page_archive\Plugin\CaptureResponse\HtmlCaptureResponse
+ *
+ * @group web_page_archive
+ */
+class HtmlCaptureResponseTest extends UnitTestCase {
+
+  /**
+   * Test runs()
+   */
+  public function testConstructor() {
+    $response = new HtmlCaptureResponse('<p>My response content</p>');
+
+    // Test getters.
+    $this->assertSame('html', $response->getType());
+    $this->assertSame('<p>My response content</p>', $response->getContent());
+
+    // Test serialized output.
+    $expected_serialized = serialize([
+      'type' => 'html',
+      'content' => '<p>My response content</p>',
+    ]);
+    $this->assertSame($expected_serialized, $response->getSerialized());
+  }
+
+}

--- a/tests/src/Unit/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
+++ b/tests/src/Unit/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
@@ -19,12 +19,12 @@ class HtmlCaptureResponseTest extends UnitTestCase {
     $response = new HtmlCaptureResponse('<p>My response content</p>');
 
     // Test getters.
-    $this->assertSame('html', $response->getType());
+    $this->assertSame(HtmlCaptureResponse::TYPE_HTML, $response->getType());
     $this->assertSame('<p>My response content</p>', $response->getContent());
 
     // Test serialized output.
     $expected_serialized = serialize([
-      'type' => 'html',
+      'type' => HtmlCaptureResponse::TYPE_HTML,
       'content' => '<p>My response content</p>',
     ]);
     $this->assertSame($expected_serialized, $response->getSerialized());

--- a/tests/src/Unit/Plugin/CaptureResponse/ScreenshotCaptureResponseTest.php
+++ b/tests/src/Unit/Plugin/CaptureResponse/ScreenshotCaptureResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CaptureResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\web_page_archive\Plugin\CaptureResponse\ScreenshotCaptureResponse;
+
+/**
+ * @coversDefaultClass \Drupal\web_page_archive\Plugin\CaptureResponse\ScreenshotCaptureResponse
+ *
+ * @group web_page_archive
+ */
+class ScreenshotCaptureResponseTest extends UnitTestCase {
+
+  /**
+   * Test runs()
+   */
+  public function testConstructor() {
+    $response = new ScreenshotCaptureResponse('<p>My response content</p>');
+
+    // Test getters.
+    $this->assertSame('uri', $response->getType());
+    $this->assertSame('<p>My response content</p>', $response->getContent());
+
+    // Test serialized output.
+    $expected_serialized = serialize([
+      'type' => 'uri',
+      'content' => '<p>My response content</p>',
+    ]);
+    $this->assertSame($expected_serialized, $response->getSerialized());
+  }
+
+}

--- a/tests/src/Unit/Plugin/CaptureResponse/ScreenshotCaptureResponseTest.php
+++ b/tests/src/Unit/Plugin/CaptureResponse/ScreenshotCaptureResponseTest.php
@@ -19,12 +19,12 @@ class ScreenshotCaptureResponseTest extends UnitTestCase {
     $response = new ScreenshotCaptureResponse('<p>My response content</p>');
 
     // Test getters.
-    $this->assertSame('uri', $response->getType());
+    $this->assertSame(ScreenshotCaptureResponse::TYPE_URI, $response->getType());
     $this->assertSame('<p>My response content</p>', $response->getContent());
 
     // Test serialized output.
     $expected_serialized = serialize([
-      'type' => 'uri',
+      'type' => ScreenshotCaptureResponse::TYPE_URI,
       'content' => '<p>My response content</p>',
     ]);
     $this->assertSame($expected_serialized, $response->getSerialized());

--- a/web_page_archive.services.yml
+++ b/web_page_archive.services.yml
@@ -1,0 +1,4 @@
+services:
+  plugin.manager.capture_utility:
+    class: Drupal\web_page_archive\Plugin\CaptureUtilityManager
+    parent: default_plugin_manager


### PR DESCRIPTION
This PR adds the capture utility plugins and response classes. To prevent a mega-PR, I'm submitting this task iteratively.  

- af3882c77fe9627b58bd5f027e3d0d9a2334d3b0 - Creates the plugin type skeleton via drupal console
- fd33e65dfc62494be5e71adcf4d6f5410b1ec0de - Adds base html/screenshot capture plugins.
- 15d262991f72181087c6522e3b4d558064f3648f - Creates html/screenshot response classes.
- f7b383c23bce2a847d2729b2caf598393426c23b - Update entity creation tests for capture utility
- 6e6e0e8642fa5f5eaade874a0e9ded77d786246e - Moved plugin updates from form submit to entity save to support programmatic entity creation
- 4a67470b5a7c79566d37c2294bd12910aac5b0ab - Add unit tests for response classes. 
- 286ff13ef384c1aa8c1cbbe3b268473a052c8573 - Switch response types to constants.