### PR TITLE
RSWEB-9355-3: Split up queues, Start runs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+root = true
+
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ before_script:
   - drupal-ti before_script
 
 script:
-  - phpcs --standard=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml src/ tests/
+  - phpcs --standard=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml ./ --extensions=php,module,inc,install,test,profile,theme --ignore=vendor/
   - drupal-ti script
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ## Instructions
 
-Unpack in the *modules* folder (currently in the root of your Drupal 8 installation) and enable in `/admin/modules`.
+Unpack in the *modules* folder (currently in the root of your Drupal 8
+installation) and enable in `/admin/modules`.
 
-Then visit `/admin/config/development/web-page-archive` to configure the web page archive integration.
+Then visit `/admin/config/development/web-page-archive` to configure the web
+page archive integration.
 
 ## Contributing
 

--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -44,12 +44,22 @@ web_page_archive.web_page_archive.*:
           timestamp:
             type: string
             label: 'Timestamp'
-          capture_url:
-            type: uri
-            label: 'Capture URL'
-          screenshot:
-            type: uri
-            label: 'Screenshot'
-          html:
-            type: string
-            label: 'HTML snapshot'
+          captures:
+            type: sequence
+            sequence:
+              type: mapping
+              mapping:
+                uuid:
+                  type: string
+                queue_ct:
+                  type: integer
+                  label: 'Queue Ct'
+                capture_url:
+                  type: uri
+                  label: 'Capture URL'
+                capture_type:
+                  type: string
+                  label: 'Capture Type'
+                content:
+                  type: string
+                  label: 'Capture Content'

--- a/src/Controller/WebPageArchiveController.php
+++ b/src/Controller/WebPageArchiveController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\web_page_archive\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Queue\QueueFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class WebPageArchiveController.
+ *
+ * @package Drupal\web_page_archive\Controller
+ */
+class WebPageArchiveController extends ControllerBase {
+
+  /**
+   * Drupal\Core\Queue\QueueFactory definition.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queue;
+
+  /**
+   * Constructs a new WebPageArchiveController object.
+   */
+  public function __construct(QueueFactory $queue) {
+    $this->queue = $queue;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('queue')
+    );
+  }
+
+  /**
+   * Returns render array for displaying run history.
+   */
+  public function viewRuns($web_page_archive) {
+    return [
+      '#theme' => 'web_page_archive',
+      '#test_var' => $this->t('Test Value'),
+    ];
+  }
+
+  /**
+   * Returns title of the archive.
+   */
+  public function title($web_page_archive) {
+    return $web_page_archive->label();
+  }
+
+}

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -255,7 +255,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
         }
       }
     }
-    catch (Exception $e) {
+    catch (\Exception $e) {
       // TODO: What to do here? (future task)
       drupal_set_message($e->getMessage(), 'warning');
     }

--- a/src/Entity/WebPageArchiveTypeInfo.php
+++ b/src/Entity/WebPageArchiveTypeInfo.php
@@ -74,7 +74,6 @@ class WebPageArchiveTypeInfo implements ContainerInjectionInterface {
   public function entityOperation(EntityInterface $entity) {
     $operations = [];
     if ($this->currentUser->hasPermission('access web_page_archive information')) {
-      // TODO: Add "Start Run" button.
       if ($entity->hasLinkTemplate('view')) {
         $operations['web_page_archive_view'] = [
           'title' => $this->t('View Run History'),
@@ -83,12 +82,15 @@ class WebPageArchiveTypeInfo implements ContainerInjectionInterface {
         ];
       }
       if ($entity->hasLinkTemplate('queue_form')) {
+        $title = $entity->getQueueCt() > 0 ? $this->t('Queue') : $this->t('Start Run');
+
         $operations['web_page_archive_queue'] = [
-          'title' => $this->t('Queue'),
+          'title' => $title,
           'weight' => 0,
           'url' => $entity->toUrl('queue_form'),
         ];
       }
+
     }
     return $operations;
   }

--- a/src/Entity/WebPageArchiveTypeInfo.php
+++ b/src/Entity/WebPageArchiveTypeInfo.php
@@ -56,7 +56,7 @@ class WebPageArchiveTypeInfo implements ContainerInjectionInterface {
    */
   public function entityTypeAlter(array &$entity_types) {
     $entity_type = $entity_types['web_page_archive'];
-    $entity_type->setLinkTemplate('view', "/admin/config/development/web-page-archive/{web_page_archive}");
+    $entity_type->setLinkTemplate('canonical', "/admin/config/development/web-page-archive/{web_page_archive}");
     $entity_type->setLinkTemplate('queue_form', "/admin/config/development/web-page-archive/{web_page_archive}/queue");
   }
 
@@ -74,11 +74,11 @@ class WebPageArchiveTypeInfo implements ContainerInjectionInterface {
   public function entityOperation(EntityInterface $entity) {
     $operations = [];
     if ($this->currentUser->hasPermission('access web_page_archive information')) {
-      if ($entity->hasLinkTemplate('view')) {
+      if ($entity->hasLinkTemplate('canonical')) {
         $operations['web_page_archive_view'] = [
           'title' => $this->t('View Run History'),
           'weight' => -1,
-          'url' => $entity->toUrl('view'),
+          'url' => $entity->toUrl('canonical'),
         ];
       }
       if ($entity->hasLinkTemplate('queue_form')) {

--- a/src/Entity/WebPageArchiveTypeInfo.php
+++ b/src/Entity/WebPageArchiveTypeInfo.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\web_page_archive\Entity;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Manipulates entity type information.
+ *
+ * This class contains primarily bridged hooks for compile-time or
+ * cache-clear-time hooks. Runtime hooks should be placed in EntityOperations.
+ */
+class WebPageArchiveTypeInfo implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * EntityTypeInfo constructor.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user.
+   */
+  public function __construct(AccountInterface $current_user) {
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * Adds links to web_page_archive entities.
+   *
+   * This is an alter hook bridge.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface[] $entity_types
+   *   The master entity type list to alter.
+   *
+   * @see hook_entity_type_alter()
+   */
+  public function entityTypeAlter(array &$entity_types) {
+    $entity_type = $entity_types['web_page_archive'];
+    $entity_type->setLinkTemplate('view', "/admin/config/development/web-page-archive/{web_page_archive}");
+    $entity_type->setLinkTemplate('queue_form', "/admin/config/development/web-page-archive/{web_page_archive}/queue");
+  }
+
+  /**
+   * Adds operations on web_page_archive entities.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity on which to define an operation.
+   *
+   * @return array
+   *   An array of operation definitions.
+   *
+   * @see hook_entity_operation()
+   */
+  public function entityOperation(EntityInterface $entity) {
+    $operations = [];
+    if ($this->currentUser->hasPermission('access web_page_archive information')) {
+      // TODO: Add "Start Run" button.
+      if ($entity->hasLinkTemplate('view')) {
+        $operations['web_page_archive_view'] = [
+          'title' => $this->t('View Run History'),
+          'weight' => -1,
+          'url' => $entity->toUrl('view'),
+        ];
+      }
+      if ($entity->hasLinkTemplate('queue_form')) {
+        $operations['web_page_archive_queue'] = [
+          'title' => $this->t('Queue'),
+          'weight' => 0,
+          'url' => $entity->toUrl('queue_form'),
+        ];
+      }
+    }
+    return $operations;
+  }
+
+}

--- a/src/Form/WebPageArchiveQueueForm.php
+++ b/src/Form/WebPageArchiveQueueForm.php
@@ -75,6 +75,8 @@ class WebPageArchiveQueueForm extends EntityForm {
    * Processes the queue.
    */
   public function processQueue(array $form, FormStateInterface $form_state) {
+    // TODO: Move this behavior to controller.
+    // TODO: Add batch processing.
     $web_page_archive = $this->getEntity();
     $queue = $this->queueFactory->get("web_page_archive_capture.{$web_page_archive->uuid()}");
     $queue_worker = $this->queueManager->createInstance("web_page_archive_capture");

--- a/src/ParamConverter/WebPageArchiveParamConverter.php
+++ b/src/ParamConverter/WebPageArchiveParamConverter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\web_page_archive\ParamConverter;
+
+use Drupal\Core\ParamConverter\ParamConverterInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Converts web_page_archive parameter ids to entities.
+ */
+class WebPageArchiveParamConverter implements ParamConverterInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function convert($value, $definition, $name, array $defaults) {
+    return \Drupal::entityTypeManager()->getStorage('web_page_archive')->load($value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($definition, $name, Route $route) {
+    return (!empty($definition['type']) && $definition['type'] == 'web_page_archive');
+  }
+
+}

--- a/src/Parser/SitemapParser.php
+++ b/src/Parser/SitemapParser.php
@@ -31,6 +31,9 @@ class SitemapParser {
   /**
    * Parses a sitemap URL.
    *
+   * @throws \GuzzleHttp\Exception\ConnectException
+   *   Exception thrown in event of networking error.
+   *
    * @throws \GuzzleHttp\Exception\ClientException
    *   Exception when a client error is encountered (4xx codes).
    *

--- a/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -25,7 +25,7 @@ class HtmlCaptureUtility extends CaptureUtilityBase {
   /**
    * {@inheritdoc}
    */
-  public function captureUrl($uri) {
+  public function capture(array $data = []) {
     // TODO: Do the actual capture.
     $this->response = new HtmlCaptureResponse('<p>Simulated response</p>');
 

--- a/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -25,7 +25,7 @@ class ScreenshotCaptureUtility extends CaptureUtilityBase {
   /**
    * {@inheritdoc}
    */
-  public function captureUrl($uri) {
+  public function capture(array $data = []) {
     // TODO: Do the actual capture.
     $this->response = new ScreenshotCaptureResponse('https://upload.wikimedia.org/wikipedia/commons/c/c1/Drupal-wordmark.svg');
 

--- a/src/Plugin/CaptureUtilityInterface.php
+++ b/src/Plugin/CaptureUtilityInterface.php
@@ -12,13 +12,13 @@ interface CaptureUtilityInterface extends PluginInspectionInterface {
   /**
    * Captures the specified URL.
    *
-   * @param string|null $url
-   *   The url to capture.
+   * @param array $data
+   *   Array containing capture info.
    *
    * @return CaptureUtilityInterface
    *   Returns reference to self.
    */
-  public function captureUrl($url);
+  public function capture(array $data);
 
   /**
    * Retrieves response from most recent capture.

--- a/src/Plugin/QueueWorker/CaptureQueueWorker.php
+++ b/src/Plugin/QueueWorker/CaptureQueueWorker.php
@@ -20,7 +20,7 @@ class CaptureQueueWorker extends QueueWorkerBase {
   public function processItem($data) {
     try {
       // Check all required keys are provided.
-      $required = ['utility', 'url'];
+      $required = ['utility', 'url', 'run_uuid', 'web_page_archive'];
       foreach ($required as $key) {
         if (empty($data[$key])) {
           throw new \Exception("$key is required");
@@ -28,10 +28,10 @@ class CaptureQueueWorker extends QueueWorkerBase {
       }
 
       // Capture the response.
-      $capture_response = $data['utility']->captureUrl($data['url'])->getResponse();
+      $data['capture_response'] = $data['utility']->capture($data)->getResponse();
+      $data['web_page_archive']->markCaptureComplete($data);
 
-      // TODO: Store $capture_response->getSerialized().
-      return $capture_response;
+      return $data['capture_response'];
 
     }
     catch (\Exception $e) {

--- a/src/WebPageArchiveListBuilder.php
+++ b/src/WebPageArchiveListBuilder.php
@@ -16,6 +16,8 @@ class WebPageArchiveListBuilder extends ConfigEntityListBuilder {
   public function buildHeader() {
     $header['label'] = $this->t('Web page archive entity');
     $header['id'] = $this->t('Machine name');
+    $header['runs'] = $this->t('Runs');
+    $header['status'] = $this->t('Status');
     return $header + parent::buildHeader();
   }
 
@@ -25,6 +27,14 @@ class WebPageArchiveListBuilder extends ConfigEntityListBuilder {
   public function buildRow(EntityInterface $entity) {
     $row['label'] = $entity->label();
     $row['id'] = $entity->id();
+    $row['runs'] = $this->formatPlural($entity->getRunCt(), '1 run', '@count runs');
+    $capture_ct = $entity->getQueueCt();
+    if ($capture_ct) {
+      $row['status'] = $this->formatPlural($capture_ct, '1 job in queue', '@count jobs in queue');
+    }
+    else {
+      $row['status'] = $this->t('No pending jobs');
+    }
     // You probably want a few more properties here...
     return $row + parent::buildRow($entity);
   }

--- a/templates/web-page-archive.html.twig
+++ b/templates/web-page-archive.html.twig
@@ -1,0 +1,3 @@
+<div id="yo">
+This is working {{ test_var }}
+</div>

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -187,7 +187,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
       'admin/config/development/web-page-archive/test_archive',
       'admin/config/development/web-page-archive/test_archive/edit',
       'admin/config/development/web-page-archive/test_archive/delete',
-      'admin/config/development/web-page-archive/queue',
+      'admin/config/development/web-page-archive/test_archive/queue',
     ];
     foreach ($urls as $url) {
       $this->drupalGet($url);

--- a/tests/src/Unit/Mock/MockAlwaysThrowingCaptureUtility.php
+++ b/tests/src/Unit/Mock/MockAlwaysThrowingCaptureUtility.php
@@ -29,7 +29,7 @@ class MockAlwaysThrowingCaptureUtility extends HtmlCaptureUtility {
   /**
    * {@inheritdoc}
    */
-  public function captureUrl($uri) {
+  public function capture(array $data = []) {
     throw new \Exception('Oh no! I could not capture the URL.');
   }
 

--- a/tests/src/Unit/Mock/MockHtmlCaptureUtility.php
+++ b/tests/src/Unit/Mock/MockHtmlCaptureUtility.php
@@ -30,7 +30,7 @@ class MockHtmlCaptureUtility extends HtmlCaptureUtility {
   /**
    * {@inheritdoc}
    */
-  public function captureUrl($uri) {
+  public function capture(array $data = []) {
     // TODO: Do the actual capture.
     $this->response = new HtmlCaptureResponse('<p>Simulated response</p>');
 

--- a/tests/src/Unit/Mock/MockScreenshotCaptureUtility.php
+++ b/tests/src/Unit/Mock/MockScreenshotCaptureUtility.php
@@ -30,7 +30,7 @@ class MockScreenshotCaptureUtility extends ScreenshotCaptureUtility {
   /**
    * {@inheritdoc}
    */
-  public function captureUrl($uri) {
+  public function capture(array $data = []) {
     // TODO: Do the actual capture.
     $this->response = new ScreenshotCaptureResponse('https://upload.wikimedia.org/wikipedia/commons/c/c1/Drupal-wordmark.svg');
 

--- a/tests/src/Unit/Mock/MockWebPageArchive.php
+++ b/tests/src/Unit/Mock/MockWebPageArchive.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Mock;
+
+use Drupal\web_page_archive\Entity\WebPageArchive;
+
+/**
+ * Mock screenshot capture utility.
+ */
+class MockWebPageArchive extends WebPageArchive {
+
+  /**
+   * Constructor for mock web page archive.
+   */
+  public function __construct() {
+    $values = [
+      'id' => 'mock_archive',
+      'label' => 'Mock Archive',
+      'sitemap_url' => 'http://www.somesite.com/sitemap.xml',
+      'cron_schedule' => '',
+      'capture_html' => TRUE,
+      'capture_screenshot' => TRUE,
+      'capture_utilities' => [
+        '00000000-1111-2222-3333-444455556666' => [
+          'id' => 'HtmlCaptureUtility',
+          'uuid' => '00000000-1111-2222-3333-444455556666',
+        ],
+        '99999999-8888-7777-6666-555544443333' => [
+          'id' => 'ScreenshotCaptureUtility',
+          'uuid' => '99999999-8888-7777-6666-555544443333',
+        ],
+      ],
+    ];
+    parent::__construct($values, 'web_page_archive');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function storeNewRun($uuid, $queue_ct) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function markCaptureComplete($data) {
+  }
+
+}

--- a/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
+++ b/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
@@ -6,6 +6,7 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\Tests\web_page_archive\Unit\Mock\MockAlwaysThrowingCaptureUtility;
 use Drupal\Tests\web_page_archive\Unit\Mock\MockHtmlCaptureUtility;
 use Drupal\Tests\web_page_archive\Unit\Mock\MockScreenshotCaptureUtility;
+use Drupal\Tests\web_page_archive\Unit\Mock\MockWebPageArchive;
 use Drupal\web_page_archive\Plugin\QueueWorker\CaptureQueueWorker;
 
 /**
@@ -34,6 +35,8 @@ class CaptureQueueWorkerTest extends UnitTestCase {
     $data = [
       'utility' => new MockScreenshotCaptureUtility(),
       'url' => 'http://www.whatever.com',
+      'run_uuid' => '12345678-1234-1234-1234-123456789000',
+      'web_page_archive' => new MockWebPageArchive(),
     ];
     $response = $this->queue->processItem($data);
     $this->assertSame('uri', $response->getType());
@@ -49,6 +52,8 @@ class CaptureQueueWorkerTest extends UnitTestCase {
   public function testMissingUtilityWritesMessage() {
     $data = [
       'url' => 'http://www.whatever.com',
+      'run_uuid' => '12345678-1234-1234-1234-123456789000',
+      'web_page_archive' => new MockWebPageArchive(),
     ];
     $response = $this->queue->processItem($data);
   }
@@ -62,6 +67,38 @@ class CaptureQueueWorkerTest extends UnitTestCase {
   public function testMissingUrlWritesMessage() {
     $data = [
       'utility' => new MockHtmlCaptureUtility(),
+      'run_uuid' => '12345678-1234-1234-1234-123456789000',
+      'web_page_archive' => new MockWebPageArchive(),
+    ];
+    $response = $this->queue->processItem($data);
+  }
+
+  /**
+   * Tests missing run_uuid writes message.
+   *
+   * @expectedException Exception
+   * @expectedExceptionMessage run_uuid is required
+   */
+  public function testMissingRunUuidWritesMessage() {
+    $data = [
+      'utility' => new MockHtmlCaptureUtility(),
+      'url' => 'http://www.whatever.com',
+      'web_page_archive' => new MockWebPageArchive(),
+    ];
+    $response = $this->queue->processItem($data);
+  }
+
+  /**
+   * Tests missing web_page_archive writes message.
+   *
+   * @expectedException Exception
+   * @expectedExceptionMessage web_page_archive is required
+   */
+  public function testMissingWebPageArchiveWritesMessage() {
+    $data = [
+      'utility' => new MockHtmlCaptureUtility(),
+      'url' => 'http://www.whatever.com',
+      'run_uuid' => '12345678-1234-1234-1234-123456789000',
     ];
     $response = $this->queue->processItem($data);
   }
@@ -76,6 +113,8 @@ class CaptureQueueWorkerTest extends UnitTestCase {
     $data = [
       'utility' => new MockAlwaysThrowingCaptureUtility(),
       'url' => 'http://www.whatever.com',
+      'run_uuid' => '12345678-1234-1234-1234-123456789000',
+      'web_page_archive' => new MockWebPageArchive(),
     ];
     $response = $this->queue->processItem($data);
   }

--- a/web_page_archive.links.action.yml
+++ b/web_page_archive.links.action.yml
@@ -3,8 +3,3 @@ entity.web_page_archive.add_form:
   title: 'Add Archive'
   appears_on:
     - entity.web_page_archive.collection
-entity.web_page_archive.queue:
-  route_name: 'entity.web_page_archive.queue'
-  title: 'Job Queue'
-  appears_on:
-    - entity.web_page_archive.collection

--- a/web_page_archive.module
+++ b/web_page_archive.module
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * This module holds functions useful for web page archives.
+ */
+
+use Drupal\web_page_archive\Entity\WebPageArchiveTypeInfo;
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function web_page_archive_entity_type_alter(array &$entity_types) {
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(WebPageArchiveTypeInfo::class)
+    ->entityTypeAlter($entity_types);
+}
+
+/**
+ * Implements hook_entity_operation().
+ */
+function web_page_archive_entity_operation($entity) {
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(WebPageArchiveTypeInfo::class)
+    ->entityOperation($entity);
+}

--- a/web_page_archive.module
+++ b/web_page_archive.module
@@ -24,3 +24,16 @@ function web_page_archive_entity_operation($entity) {
     ->getInstanceFromDefinition(WebPageArchiveTypeInfo::class)
     ->entityOperation($entity);
 }
+
+/**
+ * Implements hook_theme().
+ */
+function web_page_archive_theme($existing, $type, $theme, $path) {
+  return [
+    'web_page_archive' => [
+      'variables' => [
+        'test_var' => NULL,
+      ],
+    ],
+  ];
+}

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -14,12 +14,17 @@ entity.web_page_archive.add_form:
   requirements:
     _entity_create_access: 'web_page_archive'
 
-entity.web_page_archive.view:
+entity.web_page_archive.canonical:
   path: 'admin/config/development/web-page-archive/{web_page_archive}'
   defaults:
-    _title: 'View'
+    _controller: '\Drupal\web_page_archive\Controller\WebPageArchiveController::viewRuns'
+    _title_callback: '\Drupal\web_page_archive\Controller\WebPageArchiveController::title'
+  options:
+    parameters:
+      web_page_archive:
+        type: web_page_archive
   requirements:
-    _entity_access: 'web_page_archive.update'
+    _permission: 'web_page_archive.view'
 
 entity.web_page_archive.edit_form:
   path: 'admin/config/development/web-page-archive/{web_page_archive}/edit'

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -14,6 +14,13 @@ entity.web_page_archive.add_form:
   requirements:
     _entity_create_access: 'web_page_archive'
 
+entity.web_page_archive.view:
+  path: 'admin/config/development/web-page-archive/{web_page_archive}'
+  defaults:
+    _title: 'View'
+  requirements:
+    _entity_access: 'web_page_archive.update'
+
 entity.web_page_archive.edit_form:
   path: 'admin/config/development/web-page-archive/{web_page_archive}/edit'
   defaults:
@@ -30,10 +37,10 @@ entity.web_page_archive.delete_form:
   requirements:
     _entity_access: 'web_page_archive.delete'
 
-entity.web_page_archive.queue:
-  path: 'admin/config/development/web-page-archive/queue'
+entity.web_page_archive.queue_form:
+  path: 'admin/config/development/web-page-archive/{web_page_archive}/queue'
   defaults:
-    _form: '\Drupal\web_page_archive\Form\WebPageArchiveQueueForm'
+    _entity_form: 'web_page_archive.queue'
     _title: 'Web Page Archive Queue'
   requirements:
     _permission: 'administer web page archive'

--- a/web_page_archive.services.yml
+++ b/web_page_archive.services.yml
@@ -2,3 +2,7 @@ services:
   plugin.manager.capture_utility:
     class: Drupal\web_page_archive\Plugin\CaptureUtilityManager
     parent: default_plugin_manager
+  web_page_archive:
+    class: Drupal\web_page_archive\ParamConverter\WebPageArchiveParamConverter
+    tags:
+      - { name: paramconverter }


### PR DESCRIPTION
This PR is based on #3 .  That should be merged in first. 

- e641df3bddc33e8376b41c674b8a3d2401052a22 - Add editorconfig and update phpcs parameters 
- d9a795f5dea2f76271ab20d550176d301c2c42ed - Make per-entity queues instead of one queue for all config entity.
- 2570ee1185d5f838c547c7218e19fa5db25419c8 - Add "Start Run" option.
- 343f7e7b83eeebc7392fe2efb5e7aa80e058307d - Set up canonical routing. 
- 0798e6ab5b21c8379dc7814fd4a30b8bc572d29a - Properly handle network connection issues when retrieving remote sitemap.
- 53809af8f3242e4a617cc5a426d227fd910a56d2 - Store individual run captures in config entity
- f413615e32d9996d39ad59ff2aad074de81a029f - Resolves test failures with new functionality

^ as a result of the above, some additional things still need to be done. Some of this can be done in a follow up PR.  Other's might need their own Jira tickets, depending on time and how we want to tackle things. 

I've creating issue #6 for tracking these ongoing issues.  It's probably best to leave feedback there. 