### PR TITLE
RSWEB-9355-5: Final(?) Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,81 @@
 # Web Page Archive
 
-## Instructions
+The Web Page Archive module allows you to use Drupal to perform periodic
+snapshots on local and remote websites based on a specified XML sitemap.
 
-Unpack in the *modules* folder (currently in the root of your Drupal 8
+This project is currently under active development and is still in early
+alpha stages.
+
+## Requirements
+
+- Drupal 8.x
+- PHP 5.6+
+- [ImageMagick](http://php.net/manual/en/book.imagick.php)
+  - See: [Installing/Configuring](http://php.net/manual/en/imagick.setup.php)
+
+## Installation
+
+- Unpack in the *modules* folder (currently in the root of your Drupal 8
 installation) and enable in `/admin/modules`.
 
-Then visit `/admin/config/development/web-page-archive` to configure the web
-page archive integration.
+## Setting Up an Archive
+
+- Install and enable module per instructions above.
+- Navigate to `/admin/config/development/web-page-archive`.
+- Click `Add Archive` button.
+- Set options for your archive:
+  - `Label`
+    - The name of your archive
+  - `XML Sitemap URL`
+    - The url to your site's sitemap.xml file.
+  - `Capture Screenshot?`
+    - Check this box to get screenshots.
+  - `Capture HTML?`
+    - Check this box to get HTML snapshots.
+- Click `Save` button.
+
+## Running Manually
+
+- Navigate to `/admin/config/development/web-page-archive`.
+- In the far right hand column of the archive you wish to start click the
+dropdown arrow, and click the `Start Run` button.
+- Read the instructions and then click the `Start Run` button to start the
+batch processing.
+- Depending on the size of your site it may take a little while for this job to
+run. You will be navigated to the snapshot overview page upon completion.
+
+## Running Snapshot Capturing via Cron
+
+- TODO: This isn't implemented yet.
+
+## Viewing the Snapshots
+
+- Navigate to `/admin/config/development/web-page-archive`.
+- Click the `View Run History` button next the archive you wish to view in
+more detail.
+- TODO: This isn't implemented yet.
 
 ## Contributing
+
+This is still an alpha release module, and features are continuously being
+added. If you would like to assist in the development of this module, we
+welcome your help.
 
 Please follow the standards as explained in the Examples for Developers module:
 
 http://cgit.drupalcode.org/examples/tree/STANDARDS.md
+
+### Helpful Links
+
+- [Drupal.org Repo](https://www.drupal.org/sandbox/pobster/2888559)
+- [Drupal.org Issue Queue](https://www.drupal.org/project/issues/2888559)
+- [GitHub.com Repo](https://github.com/WidgetsBurritos/web_page_archive)
+
+### Ways You Can Help
+
+- Use the Module and Let Us Know Your Thoughts
+- Report Bugs
+- Submit Ideas/Patches on drupal.org
+- Submit Pull Requests on github.com
+- Write Tests
+- Write/Edit Documentation

--- a/src/Controller/WebPageArchiveController.php
+++ b/src/Controller/WebPageArchiveController.php
@@ -70,7 +70,7 @@ class WebPageArchiveController extends ControllerBase {
    * Common batch processing callback for all operations.
    */
   public static function batchProcess(WebPageArchive $web_page_archive, &$context) {
-    $queue = \Drupal::service('queue')->get("web_page_archive_capture.{$web_page_archive->uuid()}");
+    $queue = $web_page_archive->getQueue();
     $queue_worker = \Drupal::service('plugin.manager.queue_worker')->createInstance('web_page_archive_capture');
 
     // TODO: Move threshold into admin panel.

--- a/src/Controller/WebPageArchiveController.php
+++ b/src/Controller/WebPageArchiveController.php
@@ -73,32 +73,25 @@ class WebPageArchiveController extends ControllerBase {
     $queue = $web_page_archive->getQueue();
     $queue_worker = \Drupal::service('plugin.manager.queue_worker')->createInstance('web_page_archive_capture');
 
-    // TODO: Move threshold into admin panel.
-    // Per-entity or global for all settings?
-    $number_of_queue = ($queue->numberOfItems() < WEB_PAGE_ARCHIVE_BATCH_SIZE) ? $queue->numberOfItems() : WEB_PAGE_ARCHIVE_BATCH_SIZE;
-
-    for ($i = 0; $i < $number_of_queue; $i++) {
-      // Claim item and attempt to process it.
-      if ($item = $queue->claimItem()) {
-        try {
-          $queue_worker->processItem($item->data);
-          $queue->deleteItem($item);
-        }
-        catch (RequeueException $e) {
-          $queue->releaseItem($item);
-        }
-        catch (SuspendQueueException $e) {
-          $queue->releaseItem($item);
-          watchdog_exception($e);
-          break;
-        }
-        catch (\Exception $e) {
-          // In case of any other kind of exception, log it and leave the item
-          // in the queue to be processed again later.
-          watchdog_exception('cron', $e);
-        }
+    if ($item = $queue->claimItem()) {
+      try {
+        $queue_worker->processItem($item->data);
+        $queue->deleteItem($item);
+      }
+      catch (RequeueException $e) {
+        $queue->releaseItem($item);
+      }
+      catch (SuspendQueueException $e) {
+        $queue->releaseItem($item);
+        watchdog_exception($e);
+      }
+      catch (\Exception $e) {
+        // In case of any other kind of exception, log it and leave the item
+        // in the queue to be processed again later.
+        watchdog_exception('cron', $e);
       }
     }
+
   }
 
   /**

--- a/src/Entity/Routing/WebPageArchiveHtmlRouteProvider.php
+++ b/src/Entity/Routing/WebPageArchiveHtmlRouteProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\web_page_archive;
+namespace Drupal\web_page_archive\Entity\Routing;
 
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -17,7 +17,7 @@ use GuzzleHttp\HandlerStack;
  *   label = @Translation("Web Page Archive"),
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
- *     "list_builder" = "Drupal\web_page_archive\WebPageArchiveListBuilder",
+ *     "list_builder" = "Drupal\web_page_archive\Entity\WebPageArchiveListBuilder",
  *     "form" = {
  *       "add" = "Drupal\web_page_archive\Form\WebPageArchiveForm",
  *       "edit" = "Drupal\web_page_archive\Form\WebPageArchiveForm",
@@ -25,7 +25,7 @@ use GuzzleHttp\HandlerStack;
  *       "queue" = "Drupal\web_page_archive\Form\WebPageArchiveQueueForm"
  *     },
  *     "route_provider" = {
- *       "html" = "Drupal\web_page_archive\WebPageArchiveHtmlRouteProvider",
+ *       "html" = "Drupal\web_page_archive\Entity\Routing\WebPageArchiveHtmlRouteProvider",
  *     },
  *   },
  *   config_prefix = "web_page_archive",

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -228,7 +228,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
    * @var int
    */
   public function getQueueCt() {
-    $queue = \Drupal::service('queue')->get("web_page_archive_capture.{$this->uuid()}");
+    $queue = $this->getQueue();
     return (isset($queue)) ? $queue->numberOfItems() : 0;
   }
 
@@ -243,6 +243,16 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
   }
 
   /**
+   * Retrieves the queue for the archive.
+   *
+   * @return \Drupal\Core\Queue\QueueInterface
+   *   Queue object for this particular archive.
+   */
+  public function getQueue() {
+    return \Drupal::service('queue')->get("web_page_archive_capture.{$this->uuid()}");
+  }
+
+  /**
    * Queues the archive to run.
    */
   public function startNewRun(HandlerStack $handler = NULL) {
@@ -251,8 +261,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
       // TODO: Move functionality into controller?
       $sitemap_parser = new SitemapParser($handler);
       $urls = $sitemap_parser->parse($this->getSitemapUrl());
-      $queue_factory = \Drupal::service('queue');
-      $queue = $queue_factory->get("web_page_archive_capture.{$this->uuid()}");
+      $queue = $this->getQueue();
       $run_uuid = $this->uuidGenerator()->generate();
 
       foreach ($urls as $url) {

--- a/src/Entity/WebPageArchiveListBuilder.php
+++ b/src/Entity/WebPageArchiveListBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\web_page_archive;
+namespace Drupal\web_page_archive\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;

--- a/src/Form/WebPageArchiveQueueForm.php
+++ b/src/Form/WebPageArchiveQueueForm.php
@@ -84,7 +84,7 @@ class WebPageArchiveQueueForm extends EntityForm {
     ];
 
     // Create batch operations.
-    for ($i = 0; $i < ceil($queue->numberOfItems() / WEB_PAGE_ARCHIVE_BATCH_SIZE); $i++) {
+    for ($i = 0; $i < $queue->numberOfItems(); $i++) {
       $batch['operations'][] = ['Drupal\web_page_archive\Controller\WebPageArchiveController::batchProcess', [$web_page_archive]];
     }
 

--- a/src/Form/WebPageArchiveQueueForm.php
+++ b/src/Form/WebPageArchiveQueueForm.php
@@ -73,7 +73,7 @@ class WebPageArchiveQueueForm extends EntityForm {
     $web_page_archive = $this->getEntity();
     $web_page_archive->startNewRun();
 
-    $queue = $this->queueFactory->get("web_page_archive_capture.{$web_page_archive->uuid()}");
+    $queue = $web_page_archive->getQueue();
     $queue_worker = $this->queueManager->createInstance("web_page_archive_capture");
 
     // Create capture job batch.

--- a/src/Form/WebPageArchiveQueueForm.php
+++ b/src/Form/WebPageArchiveQueueForm.php
@@ -74,11 +74,11 @@ class WebPageArchiveQueueForm extends EntityForm {
     $web_page_archive->startNewRun();
 
     $queue = $web_page_archive->getQueue();
-    $queue_worker = $this->queueManager->createInstance("web_page_archive_capture");
+    $queue_worker = $this->queueManager->createInstance('web_page_archive_capture');
 
     // Create capture job batch.
     $batch = [
-      'title' => $this->t("Process all capture queue jobs with batch"),
+      'title' => $this->t('Process all capture queue jobs with batch'),
       'operations' => [],
       'finished' => 'Drupal\web_page_archive\Controller\WebPageArchiveController::batchFinished',
     ];

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -224,8 +224,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $entity = \Drupal::entityTypeManager()->getStorage('web_page_archive')->load('process_and_run_archive');
 
     // Retrieve queue.
-    $queue_factory = \Drupal::service('queue');
-    $queue = $queue_factory->get("web_page_archive_capture.{$entity->uuid()}");
+    $queue = $entity->getQueue();
 
     // Ensure queue is empty.
     $this->assertEqual(0, $queue->numberOfItems());

--- a/tests/src/Unit/Mock/MockHtmlCaptureUtility.php
+++ b/tests/src/Unit/Mock/MockHtmlCaptureUtility.php
@@ -31,9 +31,7 @@ class MockHtmlCaptureUtility extends HtmlCaptureUtility {
    * {@inheritdoc}
    */
   public function capture(array $data = []) {
-    // TODO: Do the actual capture.
     $this->response = new HtmlCaptureResponse('<p>Simulated response</p>');
-
     return $this;
   }
 

--- a/tests/src/Unit/Mock/MockScreenshotCaptureUtility.php
+++ b/tests/src/Unit/Mock/MockScreenshotCaptureUtility.php
@@ -31,9 +31,7 @@ class MockScreenshotCaptureUtility extends ScreenshotCaptureUtility {
    * {@inheritdoc}
    */
   public function capture(array $data = []) {
-    // TODO: Do the actual capture.
     $this->response = new ScreenshotCaptureResponse('https://upload.wikimedia.org/wikipedia/commons/c/c1/Drupal-wordmark.svg');
-
     return $this;
   }
 

--- a/web_page_archive.module
+++ b/web_page_archive.module
@@ -5,8 +5,6 @@
  * This module holds functions useful for web page archives.
  */
 
-define('WEB_PAGE_ARCHIVE_BATCH_SIZE', 30);
-
 use Drupal\web_page_archive\Entity\WebPageArchiveTypeInfo;
 
 /**


### PR DESCRIPTION
Dependent on #5. That needs to be merged first. 

- 01aff7a5b2c7b14f47a195e72eef945142006c95 - Relocates some entity classes under the `Entity` folder.
- 1f700a971906ae229cd7261e190bc6e7e6dffcf2 - Removed some unnecessary comments in the Mock utility classes. (Since they're mocks, they don't actually need the to-dos). 
- 1ae23860b84355db5a3b20a8057180c97786f9c8 - Added a `getQueue()` function to the entity object to minimize repetition. 
- bd260996f78e48514ae6c7de9000f33abeda02a1 - Update `README.md`
- 563e05f7e49f21887735a06db6dda9e87d8f6d55 - Only process one capture per batch
- d457739b447ced58222ca05f17e814c62de3731a - Fix quotes