### PR TITLE
Issue #2894966 by WidgetsBurritos: Canonical permissions incorrect

### DIFF
--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -12,7 +12,7 @@ entity.web_page_archive.add_form:
     _entity_form: 'web_page_archive.add'
     _title: 'Add Archive'
   requirements:
-    _entity_create_access: 'web_page_archive'
+    _permission: 'administer web page archive'
 
 entity.web_page_archive.canonical:
   path: 'admin/config/development/web-page-archive/{web_page_archive}'
@@ -24,7 +24,7 @@ entity.web_page_archive.canonical:
       web_page_archive:
         type: web_page_archive
   requirements:
-    _permission: 'web_page_archive.view'
+    _permission: 'administer web page archive'
 
 entity.web_page_archive.edit_form:
   path: 'admin/config/development/web-page-archive/{web_page_archive}/edit'
@@ -32,7 +32,7 @@ entity.web_page_archive.edit_form:
     _entity_form: 'web_page_archive.edit'
     _title: 'Edit Archive'
   requirements:
-    _entity_access: 'web_page_archive.update'
+    _permission: 'administer web page archive'
 
 entity.web_page_archive.delete_form:
   path: 'admin/config/development/web-page-archive/{web_page_archive}/delete'
@@ -40,7 +40,7 @@ entity.web_page_archive.delete_form:
     _entity_form: 'web_page_archive.delete'
     _title: 'Delete Archive'
   requirements:
-    _entity_access: 'web_page_archive.delete'
+    _permission: 'administer web page archive'
 
 entity.web_page_archive.queue_form:
   path: 'admin/config/development/web-page-archive/{web_page_archive}/queue'


### PR DESCRIPTION
Issue: https://www.drupal.org/node/2894966

[Per conversation on Performance Budget module:](https://github.com/bighappyface/performance_budget/pull/1#pullrequestreview-50113156)

---

Our entities don't currently have access handlers in the annotations. 

From https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21entity.api.php/group/entity_api/8.2.x: 

> **access:** If your configuration entity has complex permissions, you might need an access control handling, implementing \Drupal\Core\Entity\EntityAccessControlHandlerInterface, but most entities can just use the 'admin_permission' annotation instead. Note that if you are creating your own access control handler, you should override the checkAccess() and checkCreateAccess() methods, not access().

So by lacking, an entity access control handler, all of those `_entity_access` lines are meaningless.  I just tested it and I still have view access on the entity with the following requirements setup: 

```
entity.web_page_archive.canonical:
  path: 'admin/config/development/web-page-archive/{web_page_archive}'
  defaults:
    _controller: '\Drupal\web_page_archive\Controller\WebPageArchiveController::viewRuns'
    _title_callback: '\Drupal\web_page_archive\Controller\WebPageArchiveController::title'
  options:
    parameters:
      web_page_archive:
        type: web_page_archive
  requirements:
    _entity_access: 'web_page_archive.this_does_not_exist'
```

Obviously `web_page_archive.this_does_not_exist` is not defined anywhere, so what it seems to be doing is actually just failing over to this line in the entity annotation: 

```
*   admin_permission = "administer web page archive",
```

Furthermore, it doesn't appear we can leave out the requirements section, so I'd propose just changing everything to use the default admin handler for now.  We don't really have complex use cases here, so I think a single permission handling will suffice. 

So for performance budget all routes, we should have this: 

```
  requirements:
    _permission: 'administer performance budget'
```
