### PR TITLE
Issue #2894268 by WidgetsBurritos: Move routes out of "development"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ installation) and enable in `/admin/modules`.
 ## Setting Up an Archive
 
 - Install and enable module per instructions above.
-- Navigate to `/admin/config/development/web-page-archive`.
+- Navigate to `/admin/config/system/web-page-archive`.
 - Click `Add Archive` button.
 - Set options for your archive:
   - `Label`
@@ -36,7 +36,7 @@ installation) and enable in `/admin/modules`.
 
 ## Running Manually
 
-- Navigate to `/admin/config/development/web-page-archive`.
+- Navigate to `/admin/config/system/web-page-archive`.
 - In the far right hand column of the archive you wish to start click the
 dropdown arrow, and click the `Start Run` button.
 - Read the instructions and then click the `Start Run` button to start the
@@ -50,7 +50,7 @@ run. You will be navigated to the snapshot overview page upon completion.
 
 ## Viewing the Snapshots
 
-- Navigate to `/admin/config/development/web-page-archive`.
+- Navigate to `/admin/config/system/web-page-archive`.
 - Click the `View Run History` button next the archive you wish to view in
 more detail.
 - TODO: This isn't implemented yet.

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -36,12 +36,12 @@ use GuzzleHttp\HandlerStack;
  *     "label" = "label"
  *   },
  *   links = {
- *     "canonical" = "/admin/config/development/web-page-archive/{web_page_archive}",
- *     "add-form" = "/admin/config/development/web-page-archive/add",
- *     "edit-form" = "/admin/config/development/web-page-archive/{web_page_archive}/edit",
- *     "delete-form" = "/admin/config/development/web-page-archive/{web_page_archive}/delete",
- *     "queue-form" = "/admin/config/development/web-page-archive/{web_page_archive}/queue",
- *     "collection" = "/admin/config/development/web-page-archive"
+ *     "canonical" = "/admin/config/system/web-page-archive/{web_page_archive}",
+ *     "add-form" = "/admin/config/system/web-page-archive/add",
+ *     "edit-form" = "/admin/config/system/web-page-archive/{web_page_archive}/edit",
+ *     "delete-form" = "/admin/config/system/web-page-archive/{web_page_archive}/delete",
+ *     "queue-form" = "/admin/config/system/web-page-archive/{web_page_archive}/queue",
+ *     "collection" = "/admin/config/system/web-page-archive"
  *   },
  *   config_export = {
  *     "id",

--- a/src/Entity/WebPageArchiveTypeInfo.php
+++ b/src/Entity/WebPageArchiveTypeInfo.php
@@ -56,8 +56,8 @@ class WebPageArchiveTypeInfo implements ContainerInjectionInterface {
    */
   public function entityTypeAlter(array &$entity_types) {
     $entity_type = $entity_types['web_page_archive'];
-    $entity_type->setLinkTemplate('canonical', "/admin/config/development/web-page-archive/{web_page_archive}");
-    $entity_type->setLinkTemplate('queue_form', "/admin/config/development/web-page-archive/{web_page_archive}/queue");
+    $entity_type->setLinkTemplate('canonical', "/admin/config/system/web-page-archive/{web_page_archive}");
+    $entity_type->setLinkTemplate('queue_form', "/admin/config/system/web-page-archive/{web_page_archive}/queue");
   }
 
   /**

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -64,10 +64,10 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->drupalLogin($this->authorizedUser);
 
     // Verify list exists with add button.
-    $this->drupalGet('admin/config/development/web-page-archive');
-    $this->assertLinkByHref('admin/config/development/web-page-archive/add');
+    $this->drupalGet('admin/config/system/web-page-archive');
+    $this->assertLinkByHref('admin/config/system/web-page-archive/add');
     // Add an entity using the entity form.
-    $this->drupalGet('admin/config/development/web-page-archive/add');
+    $this->drupalGet('admin/config/system/web-page-archive/add');
     $this->drupalPostForm(
       NULL,
       [
@@ -89,12 +89,12 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
 
     // Verify entity view, edit, and delete buttons are present.
     // This is to ensure the entity config is correct for user operations.
-    $this->assertLinkByHref('admin/config/development/web-page-archive/test_archive');
-    $this->assertLinkByHref('admin/config/development/web-page-archive/test_archive/edit');
-    $this->assertLinkByHref('admin/config/development/web-page-archive/test_archive/delete');
+    $this->assertLinkByHref('admin/config/system/web-page-archive/test_archive');
+    $this->assertLinkByHref('admin/config/system/web-page-archive/test_archive/edit');
+    $this->assertLinkByHref('admin/config/system/web-page-archive/test_archive/delete');
 
     // Verify previous values are retained.
-    $this->drupalGet('admin/config/development/web-page-archive/test_archive/edit');
+    $this->drupalGet('admin/config/system/web-page-archive/test_archive/edit');
     $this->assertFieldByName('sitemap_url', 'http://localhost/sitemap.xml');
     $this->assertFieldChecked('capture_screenshot');
     $this->assertNoFieldChecked('capture_html');
@@ -119,7 +119,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertEqual('HtmlCaptureUtility', array_shift($capture_utilities)['id']);
 
     // Verify previous values are retained.
-    $this->drupalGet('admin/config/development/web-page-archive/test_archive/edit');
+    $this->drupalGet('admin/config/system/web-page-archive/test_archive/edit');
     $this->assertFieldByName('sitemap_url', 'http://localhost:1234/sitemap.xml');
     $this->assertNoFieldChecked('capture_screenshot');
     $this->assertFieldChecked('capture_html');
@@ -146,7 +146,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
 
     // Login.
     $this->drupalLogin($this->authorizedUser);
-    $this->drupalGet('admin/config/development/web-page-archive/programmatic_archive/edit');
+    $this->drupalGet('admin/config/system/web-page-archive/programmatic_archive/edit');
     $this->assertResponse(Response::HTTP_OK);
     $this->assertFieldByName('label', 'Programmatic Archive');
     $this->assertFieldByName('sitemap_url', 'http://localhost/sitemap.xml');
@@ -184,12 +184,12 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->drupalLogin($this->unauthorizedUser);
 
     $urls = [
-      'admin/config/development/web-page-archive',
-      'admin/config/development/web-page-archive/add',
-      'admin/config/development/web-page-archive/test_archive',
-      'admin/config/development/web-page-archive/test_archive/edit',
-      'admin/config/development/web-page-archive/test_archive/delete',
-      'admin/config/development/web-page-archive/test_archive/queue',
+      'admin/config/system/web-page-archive',
+      'admin/config/system/web-page-archive/add',
+      'admin/config/system/web-page-archive/test_archive',
+      'admin/config/system/web-page-archive/test_archive/edit',
+      'admin/config/system/web-page-archive/test_archive/delete',
+      'admin/config/system/web-page-archive/test_archive/queue',
     ];
     foreach ($urls as $url) {
       $this->drupalGet($url);

--- a/web_page_archive.links.menu.yml
+++ b/web_page_archive.links.menu.yml
@@ -3,5 +3,5 @@ entity.web_page_archive.collection:
   title: 'Web Page Archive'
   route_name: entity.web_page_archive.collection
   description: 'Settings for Web Page Archives'
-  parent: system.admin_config_development
+  parent: system.admin_config_system
   weight: 99

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -1,5 +1,5 @@
 entity.web_page_archive.collection:
-  path: 'admin/config/development/web-page-archive'
+  path: 'admin/config/system/web-page-archive'
   defaults:
     _entity_list: 'web_page_archive'
     _title: 'Web Page Archive'
@@ -7,7 +7,7 @@ entity.web_page_archive.collection:
     _permission: 'administer web page archive'
 
 entity.web_page_archive.add_form:
-  path: 'admin/config/development/web-page-archive/add'
+  path: 'admin/config/system/web-page-archive/add'
   defaults:
     _entity_form: 'web_page_archive.add'
     _title: 'Add Archive'
@@ -15,7 +15,7 @@ entity.web_page_archive.add_form:
     _entity_create_access: 'web_page_archive'
 
 entity.web_page_archive.canonical:
-  path: 'admin/config/development/web-page-archive/{web_page_archive}'
+  path: 'admin/config/system/web-page-archive/{web_page_archive}'
   defaults:
     _controller: '\Drupal\web_page_archive\Controller\WebPageArchiveController::viewRuns'
     _title_callback: '\Drupal\web_page_archive\Controller\WebPageArchiveController::title'
@@ -27,7 +27,7 @@ entity.web_page_archive.canonical:
     _permission: 'web_page_archive.view'
 
 entity.web_page_archive.edit_form:
-  path: 'admin/config/development/web-page-archive/{web_page_archive}/edit'
+  path: 'admin/config/system/web-page-archive/{web_page_archive}/edit'
   defaults:
     _entity_form: 'web_page_archive.edit'
     _title: 'Edit Archive'
@@ -35,7 +35,7 @@ entity.web_page_archive.edit_form:
     _entity_access: 'web_page_archive.update'
 
 entity.web_page_archive.delete_form:
-  path: 'admin/config/development/web-page-archive/{web_page_archive}/delete'
+  path: 'admin/config/system/web-page-archive/{web_page_archive}/delete'
   defaults:
     _entity_form: 'web_page_archive.delete'
     _title: 'Delete Archive'
@@ -43,7 +43,7 @@ entity.web_page_archive.delete_form:
     _entity_access: 'web_page_archive.delete'
 
 entity.web_page_archive.queue_form:
-  path: 'admin/config/development/web-page-archive/{web_page_archive}/queue'
+  path: 'admin/config/system/web-page-archive/{web_page_archive}/queue'
   defaults:
     _entity_form: 'web_page_archive.queue'
     _title: 'Web Page Archive Queue'


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2894268

This PR moves the entity out of `development` and into `system`. 