### PR TITLE
Issue #2894731 by WidgetsBurritos: Move form alters for capture utilities into plugins

### DIFF
--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -16,12 +16,6 @@ web_page_archive.web_page_archive.*:
     cron_schedule:
       type: string
       label: 'Cron Schedule'
-    capture_screenshot:
-      type: boolean
-      label: 'Capture Screenshot'
-    capture_html:
-      type: boolean
-      label: 'Capture HTML'
     capture_utilities:
       type: sequence
       sequence:

--- a/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\web_page_archive\Plugin\CaptureUtility;
 
+use Drupal\web_page_archive\Entity\WebPageArchive;
 use Drupal\web_page_archive\Plugin\CaptureResponse\HtmlCaptureResponse;
 use Drupal\web_page_archive\Plugin\CaptureUtilityBase;
 
@@ -37,6 +38,31 @@ class HtmlCaptureUtility extends CaptureUtilityBase {
    */
   public function getResponse() {
     return $this->response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addConfigFormFields(array $form, WebPageArchive $web_page_archive = NULL) {
+    // Default form options:
+    $config = [
+      "{$this->pluginId}" => FALSE,
+    ];
+
+    // Look for set values.
+    if (isset($web_page_archive)) {
+      $instance = $web_page_archive->hasCaptureUtilityInstance($this->pluginId);
+      $config = $instance['config'];
+    }
+    $form[$this->pluginId] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Capture HTML?'),
+      '#description' => $this->t('If checked, this job will include download and compare HTML.'),
+      // '#default_value' => $web_page_archive->isScreenshotCapturing(),
+      '#default_value' => $config[$this->pluginId],
+    ];
+
+    return $form;
   }
 
 }

--- a/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\web_page_archive\Plugin\CaptureUtility;
 
+use Drupal\web_page_archive\Entity\WebPageArchive;
 use Drupal\web_page_archive\Plugin\CaptureResponse\ScreenshotCaptureResponse;
 use Drupal\web_page_archive\Plugin\CaptureUtilityBase;
 
@@ -37,6 +38,42 @@ class ScreenshotCaptureUtility extends CaptureUtilityBase {
    */
   public function getResponse() {
     return $this->response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addConfigFormFields(array $form, WebPageArchive $web_page_archive = NULL) {
+    // Default form options:
+    $config = [
+      "{$this->pluginId}" => FALSE,
+      "{$this->pluginId}_width" => 1280,
+    ];
+
+    // Look for set values.
+    if (isset($web_page_archive)) {
+      $instance = $web_page_archive->hasCaptureUtilityInstance($this->pluginId);
+      $config = $instance['config'];
+    }
+
+    // Setup form fields.
+    $form[$this->pluginId] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Capture Screenshot?'),
+      '#description' => $this->t('If checked, this job will include download and compare screenshots.'),
+      // '#default_value' => $web_page_archive->isScreenshotCapturing(),
+      '#default_value' => $config[$this->pluginId],
+    ];
+    $form["{$this->pluginId}_width"] = [
+      '#type' => 'number',
+      '#title' => $this->t('Capture width (in pixels)'),
+      '#description' => $this->t('Specify the width you would like to capture.'),
+      // '#default_value' => $web_page_archive->isScreenshotCapturing(),
+      // '#default_value' => TRUE,
+      '#default_value' => $config["{$this->pluginId}_width"],
+    ];
+
+    return $form;
   }
 
 }

--- a/src/Plugin/CaptureUtilityBase.php
+++ b/src/Plugin/CaptureUtilityBase.php
@@ -3,10 +3,15 @@
 namespace Drupal\web_page_archive\Plugin;
 
 use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Base class for Capture utility plugins.
  */
 abstract class CaptureUtilityBase extends PluginBase implements CaptureUtilityInterface {
+  use StringTranslationTrait;
 
+  function getFormFields() {
+    return array_keys($this->addConfigFormFields([]));
+  }
 }

--- a/src/Plugin/CaptureUtilityInterface.php
+++ b/src/Plugin/CaptureUtilityInterface.php
@@ -3,6 +3,7 @@
 namespace Drupal\web_page_archive\Plugin;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\web_page_archive\Entity\WebPageArchive;
 
 /**
  * Defines an interface for Capture utility plugins.
@@ -27,5 +28,18 @@ interface CaptureUtilityInterface extends PluginInspectionInterface {
    *   A capture response object.
    */
   public function getResponse();
+
+  /**
+   * Adds fields to config form. The toggle checkbox key should be the id of
+   * the capture utility plugin. It is recommending that all form fields are
+   * prefixed with the plugin id to reduce risk of duplicate fields.
+   *
+   * @param array
+   *   Form array.
+   *
+   * @return array
+   *   Modified form array.
+   */
+  public function addConfigFormFields(array $form, WebPageArchive $web_page_archive = NULL);
 
 }


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2894731

This PR moves plugin form functionality out of the main module and into individual plugins.

Ignore the changes here. This is still WIP. I'm working on shifting some of the form functionality into a buildConfigurationForm() function, similar to how the image module manages it .