### PR TITLE
Issue #2894262 by WidgetsBurritos: Cleanup on uninstall

### DIFF
--- a/src/Controller/PrepareUninstallController.php
+++ b/src/Controller/PrepareUninstallController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\web_page_archive\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Class WebPageArchiveController.
+ *
+ * @package Drupal\web_page_archive\Controller
+ */
+class PrepareUninstallController extends ControllerBase {
+
+  /**
+   * Deletes web_page_archive subscribers.
+   */
+  public static function deleteRunEntities(&$context) {
+    $run_ids = \Drupal::entityQuery('web_page_archive_run')->range(0, 100)->execute();
+    $storage = \Drupal::entityManager()->getStorage('web_page_archive_run');
+    if ($run = $storage->loadMultiple($run_ids)) {
+      $storage->delete($run);
+    }
+    $context['finished'] = (int) count($subscriber_ids) < 100;
+  }
+
+  /**
+   * Removes web_page_archive fields.
+   */
+  public static function removeFields() {
+    $config = \Drupal::configFactory();
+    $config->getEditable('field.field.web_page_archive_run.web_page_archive_run.field_captures')->delete();
+    $config->getEditable('core.entity_form_display.web_page_archive_run.web_page_archive_run')->delete();
+    $config->getEditable('field.storage.web_page_archive_run.field_captures')->delete();
+  }
+
+}

--- a/src/Form/PrepareUninstallForm.php
+++ b/src/Form/PrepareUninstallForm.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\web_page_archive\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Removes fields and data used by web_page_archive.
+ */
+class PrepareUninstallForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'web_page_archive_admin_prepare_uninstall';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['web_page_archive'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Prepare uninstall'),
+      '#description' => $this->t('When clicked all web_page_archive data (content, fields) will be removed.'),
+    ];
+
+    $form['web_page_archive']['prepare_uninstall'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Delete web_page_archive data'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $batch = [
+      'title' => t('Prepare for uninstall.'),
+      'operations' => [
+        [
+          'Drupal\web_page_archive\Controller\PrepareUninstallController::deleteRunEntities', [],
+        ],
+        [
+          'Drupal\web_page_archive\Controller\PrepareUninstallController::removeFields', [],
+        ],
+      ],
+      'progress_message' => static::t('Deleting web_page_archive data... Completed @percentage% (@current of @total).'),
+    ];
+    batch_set($batch);
+
+    drupal_set_message($this->t('web_page_archive data has been deleted.'));
+  }
+
+}

--- a/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -45,7 +45,7 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
     }
 
     $file_path = \Drupal::service('file_system')->realpath(file_default_scheme() . "://");
-    $save_dir = "{$file_path}/screenshots/{$data['web_page_archive']->id()}/{$data['run_uuid']}";
+    $save_dir = "{$file_path}/web-page-archive/{$data['web_page_archive']->id()}/{$data['run_uuid']}";
     $file_name = preg_replace('/[^a-z0-9]+/', '-', strtolower($url));
     $file_location = "{$save_dir}/{$file_name}";
     $screenCapture->save($file_location);

--- a/web_page_archive.drush.inc
+++ b/web_page_archive.drush.inc
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file
+ * Drush commands for web_page_archive.
+ */
+
+/**
+ * Implements web_page_archive_drush_command().
+ */
+function web_page_archive_drush_command() {
+  $items = [];
+
+  $items['web-page-archive-prepare-uninstall'] = [
+    'description' => 'Prepares the web page archive for uninstalling.',
+    'aliases' => ['wpa-pu'],
+    'drupal dependencies' => ['web_page_archive'],
+    'options' => [],
+  ];
+
+  return $items;
+}
+
+/**
+ * Drush callback to prepare for uninstall.
+ */
+function drush_web_page_archive_prepare_uninstall() {
+  if (drush_confirm('Are you sure you want to delete the entities?')) {
+    $batch = [
+      'title' => t('Prepare for uninstall.'),
+      'operations' => [
+        [
+          'Drupal\web_page_archive\Controller\PrepareUninstallController::deleteRunEntities', [],
+        ],
+        [
+          'Drupal\web_page_archive\Controller\PrepareUninstallController::removeFields', [],
+        ],
+      ],
+      'progress_message' => t('Deleting web_page_archive data... Completed @percentage% (@current of @total).'),
+    ];
+    batch_set($batch);
+
+    // Process the batch.
+    drush_backend_batch_process();
+  }
+  else {
+    drush_user_abort();
+  }
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file
+ * Install commands for web_page_archive.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function web_page_archive_uninstall() {
+  // Delete unbatched queues.
+  $query = \Drupal::database()->delete('queue');
+  $query->condition('name', 'web_page_archive_capture.%', 'LIKE');
+  $query->execute();
+
+  // Delete batched queues.
+  $query = \Drupal::database()->select('queue', 'q');
+  $query->fields('q', ['name', 'data']);
+  $query->condition('q.data', '%web_page_archive%', 'LIKE');
+  $rows = $query->execute()->fetchAllKeyed();
+
+  $batch_methods_to_remove = [
+    'Drupal\web_page_archive\Controller\WebPageArchiveController::batchProcess',
+    'Drupal\web_page_archive\Controller\PrepareUninstallController::deleteRunEntities',
+    'Drupal\web_page_archive\Controller\PrepareUninstallController::removeFields',
+  ];
+
+  foreach ($rows as $key => $value) {
+    $data = unserialize($value);
+    if (isset($data[0]) && in_array($data[0], $batch_methods_to_remove)) {
+      $query = \Drupal::database()->delete('queue');
+      $query->condition('name', $key);
+      $query->execute();
+    }
+    $tokens = explode(':', $key);
+    $query = \Drupal::database()->delete('batch');
+    $query->condition('bid', $tokens[1]);
+    $query->execute();
+  }
+
+  // Delete files.
+  file_unmanaged_delete_recursive(file_default_scheme() . '://web-page-archive');
+
+  // Delete locks.
+  $query = \Drupal::database()->delete('semaphore');
+  $query->condition('name', 'web_page_archive_run');
+  $query->execute();
+}

--- a/web_page_archive.links.task.yml
+++ b/web_page_archive.links.task.yml
@@ -24,3 +24,15 @@ entity.web_page_archive_run.delete_form:
   base_route:  entity.web_page_archive_run.canonical
   title: Delete
   weight: 10
+
+entity.web_page_archive.collection:
+  title: 'Web Page Archive'
+  route_name: entity.web_page_archive.collection
+  base_route: entity.web_page_archive.collection
+
+entity.web_page_archive.collection.prepare_uninstall:
+  title: 'Prepare uninstall'
+  description: 'Remove fields and data created by web page archive module.'
+  base_route: entity.web_page_archive.collection
+  route_name: entity.web_page_archive.collection.prepare_uninstall
+  weight: -4

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -51,7 +51,7 @@ entity.web_page_archive.queue_form:
     _permission: 'administer web page archive'
 
 web_page_archive.capture_utility_add_form:
-  path: 'admin/config/development/web-page-archive/{web_page_archive}/add/{capture_utility}'
+  path: 'admin/config/system/web-page-archive/{web_page_archive}/add/{capture_utility}'
   defaults:
     _form: '\Drupal\web_page_archive\Form\CaptureUtilityAddForm'
     _title: 'Add capture utility'
@@ -59,7 +59,7 @@ web_page_archive.capture_utility_add_form:
     _permission: 'administer web page archive'
 
 web_page_archive.capture_utility_edit_form:
-  path: 'admin/config/development/web-page-archive/{web_page_archive}/utilities/{capture_utility}'
+  path: 'admin/config/system/web-page-archive/{web_page_archive}/utilities/{capture_utility}'
   defaults:
     _form: '\Drupal\web_page_archive\Form\CaptureUtilityEditForm'
     _title: 'Edit capture utility'
@@ -67,9 +67,17 @@ web_page_archive.capture_utility_edit_form:
     _permission: 'administer web page archive'
 
 web_page_archive.capture_utility_delete_form:
-  path: 'admin/config/development/web-page-archive/{web_page_archive}/utilities/{capture_utility}/delete'
+  path: 'admin/config/system/web-page-archive/{web_page_archive}/utilities/{capture_utility}/delete'
   defaults:
     _form: '\Drupal\web_page_archive\Form\CaptureUtilityDeleteForm'
     _title: 'Delete capture utility'
+  requirements:
+    _permission: 'administer web page archive'
+
+entity.web_page_archive.collection.prepare_uninstall:
+  path: 'admin/config/system/web-page-archive/uninstall'
+  defaults:
+    _form: '\Drupal\web_page_archive\Form\PrepareUninstallForm'
+    _title: 'Prepare uninstall'
   requirements:
     _permission: 'administer web page archive'


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2894262

This PR cleans up on uninstall. 

It also introduces the "prepare for uninstall" option as a form and drush command for cleanup, since there are still issues in D8. 

To cleanly uninstall and reinstall your module you can now do this:
```
drush wpa-pu -y && drush dre -y web_page_archive
```

