### PR TITLE
Issue #2894024 by WidgetsBurritos: Add UI to Archive Entity Canonical View

### DIFF
--- a/config/install/views.view.web_page_archive_canonical.yml
+++ b/config/install/views.view.web_page_archive_canonical.yml
@@ -1,0 +1,509 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - web_page_archive
+id: web_page_archive_canonical
+label: 'Web Page Archive Canonical'
+module: views
+description: 'Canonical view of web page archive configuration entity'
+tag: ''
+base_table: web_page_archive_run_revision
+base_field: vid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+          expose:
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: true
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            id: id
+          info:
+            id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        vid:
+          id: vid
+          table: web_page_archive_run_revision
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: 'View Details'
+            make_link: true
+            path: 'admin/structure/views/some-path/{{ vid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: web_page_archive_run
+          entity_field: vid
+          plugin_id: field
+        revision_created:
+          id: revision_created
+          table: web_page_archive_run_revision
+          field: revision_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: web_page_archive_run
+          entity_field: revision_created
+          plugin_id: field
+        queue_ct:
+          id: queue_ct
+          table: web_page_archive_run_revision
+          field: queue_ct
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Queue Size'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: web_page_archive_run
+          entity_field: queue_ct
+          plugin_id: field
+        dropbutton:
+          id: dropbutton
+          table: views
+          field: dropbutton
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          fields:
+            vid: vid
+            revision_created: '0'
+            queue_ct: '0'
+          destination: true
+          plugin_id: dropbutton
+      filters:
+        queue_ct:
+          id: queue_ct
+          table: web_page_archive_run_revision
+          field: queue_ct
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: '0'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: web_page_archive_run
+          entity_field: queue_ct
+          plugin_id: numeric
+      sorts:
+        revision_created:
+          id: revision_created
+          table: web_page_archive_run_revision
+          field: revision_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: true
+          expose:
+            label: 'Revision create time'
+          granularity: day
+          entity_type: web_page_archive_run
+          entity_field: revision_created
+          plugin_id: date
+        queue_ct:
+          id: queue_ct
+          table: web_page_archive_run_revision
+          field: queue_ct
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: true
+          expose:
+            label: 'Queue Size'
+          entity_type: web_page_archive_run
+          entity_field: queue_ct
+          plugin_id: standard
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: '<a href="#" class="button button--primary">Start a new run</a>'
+          plugin_id: text_custom
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No capture results could be found. Click the "Start a new run" button above to begin.'
+          plugin_id: text_custom
+      relationships: {  }
+      arguments:
+        id:
+          id: id
+          table: web_page_archive_run_revision
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: web_page_archive_run
+          entity_field: id
+          plugin_id: numeric
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+      tags: {  }
+  canonical_embed:
+    display_plugin: embed
+    id: canonical_embed
+    display_title: Embed
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+      tags: {  }

--- a/config/install/views.view.web_page_archive_canonical.yml
+++ b/config/install/views.view.web_page_archive_canonical.yml
@@ -290,6 +290,138 @@ display:
           entity_type: web_page_archive_run
           entity_field: queue_ct
           plugin_id: field
+        capture_utilities:
+          id: capture_utilities
+          table: web_page_archive_run_revision
+          field: capture_utilities
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'List of capture utilities used.'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: web_page_archive_capture_utility_map_formatter
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: web_page_archive_run
+          entity_field: capture_utilities
+          plugin_id: field
+        capture_size:
+          id: capture_size
+          table: web_page_archive_run_revision
+          field: capture_size
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Size of the capture in bytes.'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+            decimal_separator: .
+            scale: 2
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: web_page_archive_run
+          entity_field: capture_size
+          plugin_id: field
         dropbutton:
           id: dropbutton
           table: views
@@ -386,6 +518,47 @@ display:
           entity_type: web_page_archive_run
           entity_field: queue_ct
           plugin_id: numeric
+        capture_utilities:
+          id: capture_utilities
+          table: web_page_archive_run_revision
+          field: capture_utilities
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: capture_utilities_op
+            label: 'List of capture utilities used.'
+            description: ''
+            use_operator: false
+            operator: capture_utilities_op
+            identifier: capture_utilities
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: web_page_archive_run
+          entity_field: capture_utilities
+          plugin_id: web_page_archive_capture_utility_filter
       sorts:
         revision_created:
           id: revision_created
@@ -480,6 +653,10 @@ display:
           entity_field: id
           plugin_id: numeric
       display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/install/views.view.web_page_archive_canonical.yml
+++ b/config/install/views.view.web_page_archive_canonical.yml
@@ -1,8 +1,11 @@
+uuid: 471383e7-5101-44c5-96cc-f97fe0e9b907
 langcode: en
 status: true
 dependencies:
   module:
     - web_page_archive
+_core:
+  default_config_hash: EnVCMYsgh9n88WMMeb3cEkrW0E4pAWVb6NVPSg6Ufb4
 id: web_page_archive_canonical
 label: 'Web Page Archive Canonical'
 module: views
@@ -231,7 +234,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'Queue Size'
+          label: 'Queue count'
           exclude: false
           alter:
             alter_text: false
@@ -297,7 +300,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'List of capture utilities used.'
+          label: 'Capture utilities'
           exclude: false
           alter:
             alter_text: false
@@ -361,7 +364,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'Size of the capture in bytes.'
+          label: 'Capture size (bytes)'
           exclude: false
           alter:
             alter_text: false
@@ -405,10 +408,10 @@ display:
           click_sort_column: value
           type: number_decimal
           settings:
-            thousand_separator: ''
+            thousand_separator: ','
             prefix_suffix: true
             decimal_separator: .
-            scale: 2
+            scale: 0
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -531,7 +534,7 @@ display:
           exposed: true
           expose:
             operator_id: capture_utilities_op
-            label: 'List of capture utilities used.'
+            label: 'Capture utilities'
             description: ''
             use_operator: false
             operator: capture_utilities_op
@@ -585,22 +588,11 @@ display:
           order: ASC
           exposed: true
           expose:
-            label: 'Queue Size'
+            label: 'Queue count'
           entity_type: web_page_archive_run
           entity_field: queue_ct
           plugin_id: standard
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: '<a href="#" class="button button--primary">Start a new run</a>'
-          plugin_id: text_custom
+      header: {  }
       footer: {  }
       empty:
         area_text_custom:

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -175,6 +175,17 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
   /**
    * {@inheritdoc}
    */
+  public function getCaptureUtilityMap() {
+    $ids = [];
+    foreach ($this->capture_utilities as $utility) {
+      $ids[$utility['id']] = $utility['uuid'];
+    }
+    return $ids;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getPluginCollections() {
     return ['capture_utilities' => $this->getCaptureUtilities()];
   }
@@ -294,6 +305,8 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
       $run_entity->setQueueCt($queue->numberOfItems());
       $run_entity->setNewRevision();
       $run_entity->setCapturedArray([]);
+      $run_entity->setCaptureUtilities($this->getCaptureUtilityMap());
+      $run_entity->set('capture_size', 0);
       $strings = [
         '@name' => $this->label(),
         '@uuid' => $run_uuid,

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -177,8 +177,9 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
    */
   public function getCaptureUtilityMap() {
     $ids = [];
+    $definitions = $this->captureUtilityPluginManager()->getDefinitions();
     foreach ($this->capture_utilities as $utility) {
-      $ids[$utility['id']] = $utility['uuid'];
+      $ids[$utility['id']] = $definitions[$utility['id']]['label'];
     }
     return $ids;
   }

--- a/src/Entity/WebPageArchiveRun.php
+++ b/src/Entity/WebPageArchiveRun.php
@@ -227,7 +227,6 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
    */
   public function markCaptureComplete($data) {
     // TODO: Lock acquired too late?
-    // TODO: Lock per entity?
     // TODO: More performant option here:
     // This get and append method gets slower as the list grows.
     $lock = \Drupal::lock();
@@ -324,7 +323,7 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
       ->setDefaultValue(TRUE);
 
     $fields['capture_utilities'] = BaseFieldDefinition::create('map')
-      ->setLabel(t('List of capture utilities used.'))
+      ->setLabel(t('Capture utilities'))
       ->setDescription(t('A list of capture utilities used for this run.'))
       ->setRevisionable(TRUE)
       ->setDefaultValue([])
@@ -338,14 +337,14 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
       ]);
 
     $fields['queue_ct'] = BaseFieldDefinition::create('integer')
-      ->setLabel(t('Number of items in the queue.'))
-      ->setDescription(t('A boolean indicating whether the Web page archive run is published.'))
+      ->setLabel(t('Queue count'))
+      ->setDescription(t('Number of tasks in the queue.'))
       ->setRevisionable(TRUE)
       ->setDefaultValue(0);
 
     $fields['capture_size'] = BaseFieldDefinition::create('float')
-      ->setLabel(t('Size of the capture in bytes.'))
-      ->setDescription(t('A floating point number representing file size.'))
+      ->setLabel(t('Capture size'))
+      ->setDescription(t('A floating point number representing cumulative file size for a run.'))
       ->setRevisionable(TRUE)
       ->setDefaultValue(0);
 

--- a/src/Entity/WebPageArchiveRun.php
+++ b/src/Entity/WebPageArchiveRun.php
@@ -47,6 +47,7 @@ use Drupal\user\UserInterface;
  *     "langcode" = "langcode",
  *     "status" = "status",
  *     "queue_ct" = "queue_ct",
+ *     "capture_utilities" = "capture_utilities",
  *   },
  *   links = {
  *     "canonical" = "/admin/config/system/web-page-archive/runs/{web_page_archive_run}",
@@ -199,6 +200,21 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
   }
 
   /**
+   * Retrieves capture utilties used in this run.
+   */
+  public function getCaptureUtilities() {
+    return $this->get('capture_utilities');
+  }
+
+  /**
+   * Sets the capture utilities.
+   */
+  public function setCaptureUtilities(array $array) {
+    $this->set('capture_utilities', $array);
+    return $this;
+  }
+
+  /**
    * Sets the captured array.
    */
   public function setCapturedArray(array $array) {
@@ -215,11 +231,21 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
     // TODO: More performant option here:
     // This get and append method gets slower as the list grows.
     $lock = \Drupal::lock();
-    if ($lock->acquire('web_page_archive_run')) {
+    $lock_id = "web_page_archive_run:{$this->uuid()}";
+    if ($lock->acquire($lock_id)) {
       $entity = \Drupal::service('entity.repository')->loadEntityByUuid('web_page_archive_run', $this->uuid());
 
       $field_captures = $entity->get('field_captures');
+      // TODO: Seems like there should be a better way to get this value:
+      $total_capture_size = $entity->get('capture_size')->first()->getValue()['value'];
       $uuid = $this->uuidGenerator()->generate();
+      try {
+        $capture_size = $data['capture_response']->getCaptureSize();
+      }
+      catch (\Exception $e) {
+        // TODO: What to do here? Error log?
+        $capture_size = 0;
+      }
       $capture = [
         'uuid' => $uuid,
         'timestamp' => \Drupal::service('datetime.time')->getCurrentTime(),
@@ -227,13 +253,15 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
         'capture_url' => $data['url'],
         'capture_type' => $data['capture_response']->getType(),
         'content' => $data['capture_response']->getContent(),
+        'capture_size' => $capture_size,
       ];
       $field_captures->appendItem(serialize($capture));
+      $entity->set('capture_size', $total_capture_size + $capture_size);
       $entity->save();
       $timeout = $this->getConfigEntity()->getTimeout();
 
       usleep(1000 * $timeout);
-      $lock->release('web_page_archive_run');
+      $lock->release($lock_id);
     }
   }
 
@@ -295,9 +323,29 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
       ->setRevisionable(TRUE)
       ->setDefaultValue(TRUE);
 
+    $fields['capture_utilities'] = BaseFieldDefinition::create('map')
+      ->setLabel(t('List of capture utilities used.'))
+      ->setDescription(t('A list of capture utilities used for this run.'))
+      ->setRevisionable(TRUE)
+      ->setDefaultValue([])
+      ->setDisplayOptions('view', [
+        'type' => 'web_page_archive_capture_utility_map_formatter',
+        'weight' => -4,
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'web_page_archive_capture_utility_map_widget',
+        'weight' => -4,
+      ]);
+
     $fields['queue_ct'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Number of items in the queue.'))
       ->setDescription(t('A boolean indicating whether the Web page archive run is published.'))
+      ->setRevisionable(TRUE)
+      ->setDefaultValue(0);
+
+    $fields['capture_size'] = BaseFieldDefinition::create('float')
+      ->setLabel(t('Size of the capture in bytes.'))
+      ->setDescription(t('A floating point number representing file size.'))
       ->setRevisionable(TRUE)
       ->setDefaultValue(0);
 

--- a/src/Entity/WebPageArchiveRunViewsData.php
+++ b/src/Entity/WebPageArchiveRunViewsData.php
@@ -15,8 +15,23 @@ class WebPageArchiveRunViewsData extends EntityViewsData {
   public function getViewsData() {
     $data = parent::getViewsData();
 
-    // Additional information for Views integration, such as table joins, can be
-    // put here.
+    $data['web_page_archive_run_revision']['capture_utilities']['filter']['id'] = 'web_page_archive_capture_utility_filter';
+
+    // We need to setup relationship from revision to entity, until core issue
+    // is resolved.
+    // @see https://www.drupal.org/node/2652652
+    $data['web_page_archive_run_revision']['id']['relationship']['id'] = 'standard';
+    $data['web_page_archive_run_revision']['id']['relationship']['base'] = 'web_page_archive_run';
+    $data['web_page_archive_run_revision']['id']['relationship']['base field'] = 'id';
+    $data['web_page_archive_run_revision']['id']['relationship']['title'] = $this->t('Web Page Archive Run');
+    $data['web_page_archive_run_revision']['id']['relationship']['label'] = $this->t('Get the web page archive run from a web page archive run revision.');
+
+    $data['web_page_archive_run_revision']['revision_id']['relationship']['id'] = 'standard';
+    $data['web_page_archive_run_revision']['revision_id']['relationship']['base'] = 'web_page_archive_run';
+    $data['web_page_archive_run_revision']['revision_id']['relationship']['base field'] = 'revision_id';
+    $data['web_page_archive_run_revision']['revision_id']['relationship']['title'] = $this->t('Web Page Archive Run');
+    $data['web_page_archive_run_revision']['revision_id']['relationship']['label'] = $this->t('Get the web page archive run from a web page archive run revision.');
+
     return $data;
   }
 

--- a/src/Plugin/CaptureResponse/UriCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/UriCaptureResponse.php
@@ -19,4 +19,15 @@ class UriCaptureResponse extends CaptureResponseBase {
     $this->setType(self::TYPE_URI)->setContent($content);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCaptureSize() {
+    // TODO: What to do if remote URL instead of local file path?
+    if (!is_readable($this->getContent())) {
+      throw new \Exception("Can't read file.");
+    }
+    return filesize($this->getContent());
+  }
+
 }

--- a/src/Plugin/CaptureResponseBase.php
+++ b/src/Plugin/CaptureResponseBase.php
@@ -85,4 +85,11 @@ abstract class CaptureResponseBase implements CaptureResponseInterface {
     ]);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCaptureSize() {
+    return 0;
+  }
+
 }

--- a/src/Plugin/CaptureResponseInterface.php
+++ b/src/Plugin/CaptureResponseInterface.php
@@ -31,4 +31,14 @@ interface CaptureResponseInterface {
    */
   public function getSerialized();
 
+  /**
+   * Retrieves the size of a capture in bytes.
+   *
+   * @todo Is there concern with maxint on 32-bit machines?
+   *
+   * @return int
+   *   Total bytes of capture.
+   */
+  public function getCaptureSize();
+
 }

--- a/src/Plugin/Field/FieldFormatter/CaptureUtilityMapFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CaptureUtilityMapFormatter.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\Field\FieldFormatter;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'web_page_archive_capture_formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "web_page_archive_capture_utility_map_formatter",
+ *   label = @Translation("Web page archive capture utility map formatter"),
+ *   field_types = {
+ *     "map"
+ *   }
+ * )
+ */
+class CaptureUtilityMapFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      // Implement default settings.
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    return [
+      // Implement settings form.
+    ] + parent::settingsForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    // Implement settings summary.
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $delta => $item) {
+      $elements[$delta] = ['#markup' => $this->viewValue($item)];
+    }
+
+    return $elements;
+  }
+
+  /**
+   * Generate the output appropriate for one field item.
+   *
+   * @param \Drupal\Core\Field\FieldItemInterface $item
+   *   One field item.
+   *
+   * @return string
+   *   The textual output generated.
+   */
+  protected function viewValue(FieldItemInterface $item) {
+    return nl2br(Html::escape(implode("\n", array_keys($item->toArray()))));
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/CaptureUtilityMapFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CaptureUtilityMapFormatter.php
@@ -6,7 +6,6 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of the 'web_page_archive_capture_formatter' formatter.
@@ -20,33 +19,6 @@ use Drupal\Core\Form\FormStateInterface;
  * )
  */
 class CaptureUtilityMapFormatter extends FormatterBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function defaultSettings() {
-    return [
-      // Implement default settings.
-    ] + parent::defaultSettings();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
-    return [
-      // Implement settings form.
-    ] + parent::settingsForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsSummary() {
-    $summary = [];
-    // Implement settings summary.
-    return $summary;
-  }
 
   /**
    * {@inheritdoc}
@@ -70,7 +42,7 @@ class CaptureUtilityMapFormatter extends FormatterBase {
    *   The textual output generated.
    */
   protected function viewValue(FieldItemInterface $item) {
-    return nl2br(Html::escape(implode("\n", array_keys($item->toArray()))));
+    return nl2br(Html::escape(implode("\n", array_values($item->toArray()))));
   }
 
 }

--- a/src/Plugin/Field/FieldWidget/CaptureUtilityMapWidget.php
+++ b/src/Plugin/Field/FieldWidget/CaptureUtilityMapWidget.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'web_page_archive_capture_utility_map_widget'.
+ *
+ * @FieldWidget(
+ *   id = "web_page_archive_capture_utility_map_widget",
+ *   label = @Translation("Web page archive capture utility map widget"),
+ *   field_types = {
+ *     "map"
+ *   }
+ * )
+ */
+class CaptureUtilityMapWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'size' => 60,
+      'placeholder' => '',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements = [];
+
+    $elements['size'] = [
+      '#type' => 'number',
+      '#title' => t('Size of textfield'),
+      '#default_value' => $this->getSetting('size'),
+      '#required' => TRUE,
+      '#min' => 1,
+    ];
+    $elements['placeholder'] = [
+      '#type' => 'textfield',
+      '#title' => t('Placeholder'),
+      '#default_value' => $this->getSetting('placeholder'),
+      '#description' => t('Text that will be shown inside the field until a value is entered. This hint is usually a sample value or a brief description of the expected format.'),
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $summary[] = t('Textfield size: @size', ['@size' => $this->getSetting('size')]);
+    if (!empty($this->getSetting('placeholder'))) {
+      $summary[] = t('Placeholder: @placeholder', ['@placeholder' => $this->getSetting('placeholder')]);
+    }
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $value = isset($items[$delta]->value) ? $items[$delta]->value : NULL;
+    if ($values = unserialize($value)) {
+      $element['capture_details'] = [
+        '#markup' => "<strong>{$values['capture_type']}:</strong> {$values['capture_url']}",
+      ];
+    }
+    return $element;
+  }
+
+}

--- a/src/Plugin/views/filter/CaptureUtilityFilter.php
+++ b/src/Plugin/views/filter/CaptureUtilityFilter.php
@@ -102,7 +102,7 @@ class CaptureUtilityFilter extends InOperator {
   public function getValueOptions() {
     if (!isset($this->valueOptions)) {
       $options = array_map(function ($option) {
-        return $option['id'];
+        return $option['label'];
       }, $this->pluginManager->getDefinitions());
       asort($options);
 

--- a/src/Plugin/views/filter/CaptureUtilityFilter.php
+++ b/src/Plugin/views/filter/CaptureUtilityFilter.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\views\filter;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\views\Plugin\views\filter\InOperator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * My custom numeric filter.
+ *
+ * @ViewsFilter("web_page_archive_capture_utility_filter")
+ */
+class CaptureUtilityFilter extends InOperator {
+
+  /**
+   * Constructs a Bundle object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $plugin_manager
+   *   The entity manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PluginManagerInterface $plugin_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->pluginManager = $plugin_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('plugin.manager.capture_utility')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function operators() {
+    $operators = [
+      'contains' => [
+        'title' => $this->t('Contains'),
+        'short' => $this->t('contains'),
+        'method' => 'opContains',
+        'values' => 1,
+      ],
+    ];
+
+    return $operators;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function operatorValues($values = 1) {
+    $options = [];
+    foreach ($this->operators() as $id => $info) {
+      if (isset($info['values']) && $info['values'] == $values) {
+        $options[] = $id;
+      }
+    }
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Make sure that the entity base table is in the query.
+    $this->ensureMyTable();
+
+    $field = "{$this->tableAlias}.{$this->realField}";
+
+    $info = $this->operators();
+    if (!empty($info[$this->operator]['method'])) {
+      $this->{$info[$this->operator]['method']}($field);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function opContains($field) {
+    foreach ($this->value as $value) {
+      $this->query->addWhere($this->options['group'], $field, '%' . db_like(serialize($value)) . '%', 'LIKE');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValueOptions() {
+    if (!isset($this->valueOptions)) {
+      $options = array_map(function ($option) {
+        return $option['id'];
+      }, $this->pluginManager->getDefinitions());
+      asort($options);
+
+      $this->valueOptions = $options;
+    }
+
+    return $this->valueOptions;
+  }
+
+}

--- a/templates/web-page-archive.html.twig
+++ b/templates/web-page-archive.html.twig
@@ -1,3 +1,0 @@
-<div id="yo">
-This is working {{ test_var }}
-</div>

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -132,6 +132,28 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
       'timeout' => 500,
       'url_type' => 'sitemap',
       'urls' => 'http://localhost/sitemap.xml',
+      'capture_utilities' => [
+        '12345678-9999-0000-5555-000000000000' => [
+          'uuid' => '12345678-9999-0000-5555-000000000000',
+          'id' => 'screenshot_capture_utility',
+          'weight' => 1,
+          'data' => [
+            'width' => 1280,
+            'clip_width' => 1280,
+            'background_color' => '#cc0000',
+            'user_agent' => 'testbot',
+            'image_type' => 'png',
+          ],
+        ],
+        '87654321-9999-0000-5555-999999999999' => [
+          'uuid' => '87654321-9999-0000-5555-999999999999',
+          'id' => 'html_capture_utility',
+          'weight' => 1,
+          'data' => [
+            'capture' => TRUE,
+          ],
+        ],
+      ],
     ];
     $wpa = \Drupal::entityManager()
       ->getStorage('web_page_archive')
@@ -146,14 +168,13 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('timeout', '500');
     $this->assertFieldByName('url_type', 'sitemap');
     $this->assertFieldByName('urls', 'http://localhost/sitemap.xml');
+    $assert->pageTextContains('HTML capture utility');
+    $assert->pageTextContains('Screenshot capture utility');
 
     // Verify run entity was created.
-    $this->drupalGet('admin/config/system/web-page-archive/runs');
+    $this->drupalGet('admin/config/system/web-page-archive');
     $assert->pageTextContains('Programmatic Archive');
-    $this->assertLinkByHref('admin/config/system/web-page-archive/runs/1');
-    $this->assertLinkByHref('admin/config/system/web-page-archive/runs/1/edit');
-    $this->assertLinkByHref('admin/config/system/web-page-archive/runs/1/delete');
-    $this->drupalGet('admin/config/system/web-page-archive/runs/1');
+    $this->drupalGet('admin/config/system/web-page-archive/programmatic_archive');
     $assert->pageTextContains('Programmatic Archive');
   }
 

--- a/web_page_archive.info.yml
+++ b/web_page_archive.info.yml
@@ -4,3 +4,5 @@ description: 'Provides web page data archiving and reporting functionality.'
 package: Utility
 core: 8.x
 configure: entity.web_page_archive.collection
+dependencies:
+  - drupal:views

--- a/web_page_archive.module
+++ b/web_page_archive.module
@@ -24,16 +24,3 @@ function web_page_archive_entity_operation($entity) {
     ->getInstanceFromDefinition(WebPageArchiveTypeInfo::class)
     ->entityOperation($entity);
 }
-
-/**
- * Implements hook_theme().
- */
-function web_page_archive_theme($existing, $type, $theme, $path) {
-  return [
-    'web_page_archive' => [
-      'variables' => [
-        'test_var' => NULL,
-      ],
-    ],
-  ];
-}


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2894024

This PR adds a view for the canonical config entities. 

- b857328fb570c831d2acb268bf9f09b461560564 - Adds view to controller.
- 98364eb2e90879aebad15b05d431422ff9800572 - Adds capture size and utility info to run entities.
- b5cb85a47aa66d29030c53b183effcc2f4422300 - Adds capture utility field formatters, widgets and views filters.
- 72119d1ecfb5e06a0d09589c01d2f7494e4b7783 - Adds capture utilities field to views
- 32de9dae3cf9b5897e74d01c2f6c32101e11c60b - Modifies tests to include basic coverage for UI view. 
- 3d237aa81b87ac978ce750d6badc474234f3e6bf - Minor formatting and cleanup tweaks. 
