### PR TITLE
Issue #2903481 by WidgetsBurritos: Can't select "None" url type. 

### DIFF
--- a/src/Form/WebPageArchiveFormBase.php
+++ b/src/Form/WebPageArchiveFormBase.php
@@ -94,9 +94,8 @@ abstract class WebPageArchiveFormBase extends EntityForm {
 
     $form['url_type'] = [
       '#type' => 'select',
-      '#title' => $this->t('URL Type'),
+      '#title' => $this->t('Capture Type'),
       '#options' => [
-        '' => $this->t('None'),
         'url' => $this->t('URL'),
         'sitemap' => $this->t('Sitemap URL'),
       ],
@@ -107,11 +106,15 @@ abstract class WebPageArchiveFormBase extends EntityForm {
       '#type' => 'textarea',
       '#title' => $this->t('URLs to Capture'),
       '#description' => $this->t('A list of urls to capture.'),
-      '#required' => TRUE,
       '#default_value' => $this->entity->getUrlsText(),
       '#states' => [
-        'invisible' => [
-          'select[name="url_type"]' => ['value' => ''],
+        'visible' => [
+          ['select[name="url_type"]' => ['value' => 'url']],
+          ['select[name="url_type"]' => ['value' => 'sitemap']],
+        ],
+        'required' => [
+          ['select[name="url_type"]' => ['value' => 'url']],
+          ['select[name="url_type"]' => ['value' => 'sitemap']],
         ],
       ],
     ];


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2903481

This PR:
1. Removes the "None" url type for now. 
2. Changes the label for "URL Type" to "Capture Type" to provide a slightly more generic description. This will be important if external modules adjust this form to provide their own capture types.
3. Switch `invisible` to `visible` for url state requirements. 
4. Changes `#required` to be determined by `#state`. 

Note: I'm opting to keep `#states` despite it not technically being necessary for the base module at this time.  The reason, is because in external modules, I still want the ability to easily define whether or not that list is necessary. This specifically is a point of concern for the POC configuration archive module I'm working. 