### PR TITLE
Issue #2904295 by WidgetsBurritos: Move HTML capture utility into own submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,18 @@
 
 The Web Page Archive module allows you to use Drupal to perform periodic snapshots on local and remote websites based on a list of URLs or XML sitemaps.
 
-This project is currently under active development and is still in early alpha stages.
-
-Follow the development process here: [MVP release plan](https://www.drupal.org/node/2894031)
+This project is currently under active development. Follow the development process here:
+- [8.x-1.0-alpha2 Release Plan](https://www.drupal.org/node/2901567)
 
 ## Capture Utilities
 
 Snapshots are performed by *Capture Utility* plugins. Web Page Archive provides the following capture utilities:
 
-| Plugin | Machine Name | Purpose | Module |
-|-----------------|------------------------|-----------------------------------------------------------------------|-----------------------------------|
-| HTML Capture Utility | wpa_html_capture | Captures raw HTML from URLs. | **Module**: web_page_archive |
-| Screenshot Capture Utility | wpa_screenshot_capture | Capture Screenshots of URLs (uses [PhantomJS](http://phantomjs.org/)). | **Submodule:** wpa_screenshot_capture |
-| Skeleton Capture Utility | wpa_skeleton_capture | Example code that provides a template for building additional capture utility plugins. | **Submodule:** wpa_skeleton_capture |
+| Plugin | Machine Name | Purpose |
+|-----------------|------------------------|-----------------------------------------------------------------------|
+| HTML Capture Utility | wpa_html_capture | Captures raw HTML from URLs. |
+| Screenshot Capture Utility | wpa_screenshot_capture | Capture Screenshots of URLs (uses [PhantomJS](http://phantomjs.org/)). |
+| Skeleton Capture Utility | wpa_skeleton_capture | Example code that provides a template for building additional capture utility plugins. |
 
 ## Requirements
 

--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -46,14 +46,6 @@ web_page_archive.capture_utility.*:
   type: mapping
   label: 'Capture utility settings'
 
-web_page_archive.capture_utility.wpa_html_capture:
-  type: mapping
-  label: 'HTML Capture utility'
-  mapping:
-    capture:
-      type: boolean
-      label: 'Capture?'
-
 field.widget.settings.web_page_archive_capture_widget:
   type: mapping
   label: 'Capture widget settings'

--- a/modules/wpa_html_capture/config/schema/wpa_html_capture.schema.yml
+++ b/modules/wpa_html_capture/config/schema/wpa_html_capture.schema.yml
@@ -1,0 +1,7 @@
+web_page_archive.capture_utility.wpa_html_capture:
+  type: mapping
+  label: 'HTML Capture utility'
+  mapping:
+    capture:
+      type: boolean
+      label: 'Capture?'

--- a/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\web_page_archive\Plugin\CaptureUtility;
+namespace Drupal\wpa_html_capture\Plugin\CaptureUtility;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\web_page_archive\Plugin\CaptureResponse\UriCaptureResponse;

--- a/modules/wpa_html_capture/wpa_html_capture.info.yml
+++ b/modules/wpa_html_capture/wpa_html_capture.info.yml
@@ -1,0 +1,7 @@
+name: Web Page Archive HTML Capture Utility
+type: module
+description: 'Provides an HTML capture utility based on Guzzle.'
+package: Web Page Archive
+core: 8.x
+dependencies:
+  - web_page_archive

--- a/src/Entity/WebPageArchiveListBuilder.php
+++ b/src/Entity/WebPageArchiveListBuilder.php
@@ -4,11 +4,25 @@ namespace Drupal\web_page_archive\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 
 /**
  * Provides a listing of Web page archive entity entities.
  */
 class WebPageArchiveListBuilder extends ConfigEntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load() {
+    $capture_utilities = \Drupal::service('plugin.manager.capture_utility')->getDefinitions();
+    if (empty($capture_utilities)) {
+      $url = Url::fromRoute('system.modules_list', [], ['fragment' => 'edit-modules-web-page-archive']);
+      $link = \Drupal::l($this->t('install a capture utility module'), $url);
+      \drupal_set_message($this->t('You have installed Web Page Archive, but do not have any capture utilities installed. You will need to @install before you use this module.', ['@install' => $link]), 'warning');
+    }
+    return parent::load();
+  }
 
   /**
    * {@inheritdoc}

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -39,6 +39,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
    */
   public static $modules = [
     'web_page_archive',
+    'wpa_html_capture',
     'wpa_screenshot_capture',
   ];
 

--- a/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
+++ b/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
@@ -30,7 +30,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
   /**
    * Mock HTML capture utility.
    *
-   * @var \Drupal\web_page_archive\Plugin\HtmlCaptureUtility
+   * @var \Drupal\wpa_html_capture\Plugin\HtmlCaptureUtility
    */
   protected $mockHtmlCaptureUtility;
 
@@ -50,7 +50,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
       ->setMethods(['markCaptureComplete'])
       ->getMock();
 
-    $this->mockHtmlCaptureUtility = $this->getMockBuilder('\Drupal\web_page_archive\Plugin\CaptureUtility\HtmlCaptureUtility')
+    $this->mockHtmlCaptureUtility = $this->getMockBuilder('\Drupal\wpa_html_capture\Plugin\CaptureUtility\HtmlCaptureUtility')
       ->disableOriginalConstructor()
       ->getMock();
     $this->mockHtmlCaptureUtility->expects($this->any())
@@ -143,7 +143,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
    * @expectedExceptionMessage Oh no! I could not capture the URL.
    */
   public function testProcessItemWritesMessage() {
-    $failing_utility = $this->getMockBuilder('\Drupal\web_page_archive\Plugin\CaptureUtility\HtmlCaptureUtility')
+    $failing_utility = $this->getMockBuilder('\Drupal\wpa_html_capture\Plugin\CaptureUtility\HtmlCaptureUtility')
       ->disableOriginalConstructor()
       ->getMock();
     $failing_utility->expects($this->any())


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2904295

This PR moves the HTML capture utility into its own submodule and notifies users when there aren't any capture utilities installed. 