### PR TITLE
Issue #2894275 by WidgetsBurritos, vessel_adrift, bighappyface: Clear queue when starting new run

### DIFF
--- a/config/install/views.view.web_page_archive_canonical.yml
+++ b/config/install/views.view.web_page_archive_canonical.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - web_page_archive
 _core:
-  default_config_hash: N5g_q37JbAKOHl0WQEx9-Zjxg1Rw91fUhHDgDuezug0
+  default_config_hash: 3v1lHJqrGlulKQPWXlNrYez0Ls-k4j6qsg2VdTnptOw
 id: web_page_archive_canonical
 label: 'Web Page Archive Canonical'
 module: views
@@ -230,72 +230,6 @@ display:
           entity_type: web_page_archive_run
           entity_field: revision_created
           plugin_id: field
-        queue_ct:
-          id: queue_ct
-          table: web_page_archive_run_revision
-          field: queue_ct
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Queue count'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: web_page_archive_run
-          entity_field: queue_ct
-          plugin_id: field
         capture_utilities:
           id: capture_utilities
           table: web_page_archive_run_revision
@@ -359,6 +293,72 @@ display:
           field_api_classes: false
           entity_type: web_page_archive_run
           entity_field: capture_utilities
+          plugin_id: field
+        success_ct:
+          id: success_ct
+          table: web_page_archive_run_revision
+          field: success_ct
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Items Captured'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ','
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: web_page_archive_run
+          entity_field: success_ct
           plugin_id: field
         capture_size:
           id: capture_size

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -310,6 +310,11 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
       }
 
       $queue = $this->getQueue();
+
+      // Reset queue.
+      $queue->deleteQueue();
+      $queue->createQueue();
+
       $run_uuid = $this->uuidGenerator()->generate();
       $run_entity = $this->getRunEntity();
 
@@ -378,6 +383,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
         'uuid' => $this->uuidGenerator()->generate(),
         'status' => 0,
         'queue_ct' => 0,
+        'success_ct' => 0,
         'config_entity' => $this->id(),
       ];
       $entity = $this->entityTypeManager()

--- a/src/Entity/WebPageArchiveListBuilder.php
+++ b/src/Entity/WebPageArchiveListBuilder.php
@@ -32,7 +32,6 @@ class WebPageArchiveListBuilder extends ConfigEntityListBuilder {
     $header['label'] = $this->t('Web page archive entity');
     $header['id'] = $this->t('Machine name');
     $header['runs'] = $this->t('Runs');
-    $header['status'] = $this->t('Status');
     $header['schedule'] = $this->t('Schedule');
     return $header + parent::buildHeader();
   }
@@ -44,13 +43,6 @@ class WebPageArchiveListBuilder extends ConfigEntityListBuilder {
     $row['label'] = $entity->label();
     $row['id'] = $entity->id();
     $row['runs'] = $this->formatPlural($entity->getRunCt(), '1 run', '@count runs');
-    $capture_ct = $entity->getQueueCt();
-    if ($capture_ct) {
-      $row['status'] = $this->formatPlural($capture_ct, '1 job in queue', '@count jobs in queue');
-    }
-    else {
-      $row['status'] = $this->t('No pending jobs');
-    }
 
     // Output job schedule.
     if ($entity->getUseCron() && CronExpression::isValidExpression($entity->getCronSchedule())) {

--- a/src/Entity/WebPageArchiveRun.php
+++ b/src/Entity/WebPageArchiveRun.php
@@ -40,6 +40,7 @@ use Drupal\user\UserInterface;
  *     "langcode" = "langcode",
  *     "status" = "status",
  *     "queue_ct" = "queue_ct",
+ *     "success_ct" = "success_ct",
  *     "capture_utilities" = "capture_utilities",
  *   },
  *   field_ui_base_route = "web_page_archive_run.settings"
@@ -164,6 +165,21 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
    */
   public function setQueueCt($ct) {
     $this->set('queue_ct', $ct);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSuccessCt() {
+    return $this->get('success_ct');
+  }
+
+  /**
+   * Sets number of jobs successfully ran.
+   */
+  public function setSuccessCt($ct) {
+    $this->set('success_ct', $ct);
     return $this;
   }
 
@@ -344,9 +360,14 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
 
     $fields['queue_ct'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Queue count'))
-      ->setDescription(t('Number of tasks in the queue.'))
+      ->setDescription(t('Total number of tasks in the queue.'))
       ->setRevisionable(TRUE)
       ->setDefaultValue(0);
+
+    $fields['success_ct'] = BaseFieldDefinition::create('wpa_default_integer')
+      ->setLabel(t('Success count'))
+      ->setDescription(t('Number of successfully completed in the queue.'))
+      ->setRevisionable(TRUE);
 
     $fields['capture_size'] = BaseFieldDefinition::create('float')
       ->setLabel(t('Capture size'))

--- a/src/Entity/WebPageArchiveRunInterface.php
+++ b/src/Entity/WebPageArchiveRunInterface.php
@@ -53,6 +53,22 @@ interface WebPageArchiveRunInterface extends RevisionableInterface, RevisionLogI
   public function setCreatedTime($timestamp);
 
   /**
+   * Returns total size of the run queue.
+   *
+   * @return int
+   *   Total number of items in the run queue.
+   */
+  public function getQueueCt();
+
+  /**
+   * Returns the number of items successfully completed.
+   *
+   * @return int
+   *   Total number of tasks completed.
+   */
+  public function getSuccessCt();
+
+  /**
    * Returns the Web page archive run completion status indicator.
    *
    * @return bool

--- a/src/Plugin/Field/FieldType/DefaultIntegerItem.php
+++ b/src/Plugin/Field/FieldType/DefaultIntegerItem.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Field\Plugin\Field\FieldType\IntegerItem;
+
+/**
+ * Defines the 'integer' field type.
+ *
+ * @FieldType(
+ *   id = "wpa_default_integer",
+ *   label = @Translation("Number (integer) with defaults enabled."),
+ *   description = @Translation("This field stores a number in the database as an integer."),
+ *   category = @Translation("Number"),
+ *   default_widget = "number",
+ *   default_formatter = "number_integer"
+ * )
+ */
+class DefaultIntegerItem extends IntegerItem {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) {
+    $schema = parent::schema($field_definition);
+    if (isset($field_definition->getDefaultValueLiteral()[0]['value'])) {
+      $schema['columns']['value']['default'] = $field_definition->getDefaultValueLiteral()[0]['value'];
+    }
+    else {
+      $schema['columns']['value']['default'] = 0;
+    }
+    return $schema;
+  }
+
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -5,6 +5,8 @@
  * Install commands for web_page_archive.
  */
 
+use Drupal\Core\Field\BaseFieldDefinition;
+
 /**
  * Implements hook_install().
  */
@@ -60,14 +62,14 @@ function web_page_archive_schema() {
         'unsigned' => TRUE,
         'not null' => TRUE,
         'default' => 0,
-        'description' => "Maps to {web_page_archive_run_revision__field_captures}.revision_id.",
+        'description' => 'Maps to {web_page_archive_run_revision__field_captures}.revision_id.',
       ],
       'delta' => [
         'type' => 'int',
         'unsigned' => TRUE,
         'not null' => TRUE,
         'default' => 0,
-        'description' => "Maps to {web_page_archive_run_revision__field_captures}.delta.",
+        'description' => 'Maps to {web_page_archive_run_revision__field_captures}.delta.',
       ],
       'langcode' => [
         'type' => 'varchar_ascii',
@@ -88,4 +90,35 @@ function web_page_archive_schema() {
   ];
 
   return $schema;
+}
+
+/**
+ * Add 'success_ct' to web page archive run entities.
+ */
+function web_page_archive_update_8001() {
+  $storage_definition = BaseFieldDefinition::create('wpa_default_integer')
+    ->setLabel(t('Success count'))
+    ->setDescription(t('Number of successfully completed in the queue.'))
+    ->setRevisionable(TRUE);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('success_ct', 'web_page_archive_run', 'web_page_archive_run', $storage_definition);
+}
+
+/**
+ * Initialize success_ct values.
+ */
+function web_page_archive_update_8002() {
+  $query = \Drupal::database()->select('web_page_archive_run_revision__field_captures', 'fc');
+  $query->addField('fc', 'revision_id');
+  $query->groupBy('fc.revision_id');
+  $query->addExpression('COUNT(*)', 'count');
+  $results = $query->execute()->fetchAllKeyed();
+
+  foreach ($results as $revision_id => $count) {
+    $query = \Drupal::database()->update('web_page_archive_run_revision');
+    $query->fields(['success_ct' => $count]);
+    $query->condition('vid', $revision_id);
+    $query->execute();
+  }
 }


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2894275

This PR clears out the queue before starting a new job. 

Note: I had to do something weird with the integer schema field in regards to the update hook.  Due to a weird bug in Drupal I couldn't use the standard `integer` plugin because it doesn't allow you to set a default value, and it was failing because it was trying to set the value to `NULL` despite being a non-null field type.  To overcome this, I had to override the core integer plugin, with my own version that allows for default values.  

It seems like this would be something core would provide but alas it does not at the present time. I may create a core issue and attempt to resolve this at a later time, but in the mean time, this works. 