### PR TITLE
Issue #2905724 by WidgetsBurritos: Delete files on deletion of configuration entity

### DIFF
--- a/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -87,4 +87,11 @@ class HtmlCaptureUtility extends ConfigurableCaptureUtilityBase {
     $this->configuration['capture'] = $form_state->getValue('capture');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function cleanupRevision($revision_id) {
+    UriCaptureResponse::cleanupRevision($revision_id);
+  }
+
 }

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -155,4 +155,11 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
     $this->configuration['image_type'] = $form_state->getValue('image_type');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function cleanupRevision($revision_id) {
+    ScreenshotCaptureResponse::cleanupRevision($revision_id);
+  }
+
 }

--- a/modules/wpa_skeleton_capture/src/Plugin/CaptureUtility/SkeletonCaptureUtility.php
+++ b/modules/wpa_skeleton_capture/src/Plugin/CaptureUtility/SkeletonCaptureUtility.php
@@ -83,4 +83,11 @@ class SkeletonCaptureUtility extends ConfigurableCaptureUtilityBase {
     $this->configuration['width'] = $form_state->getValue('width');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function cleanupRevision($revision_id) {
+    UriCaptureResponse::cleanupRevision($revision_id);
+  }
+
 }

--- a/src/Controller/CleanupController.php
+++ b/src/Controller/CleanupController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\web_page_archive\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Queue\RequeueException;
+
+/**
+ * Class WebPageArchiveController.
+ *
+ * @package Drupal\web_page_archive\Controller
+ */
+class CleanupController extends ControllerBase {
+
+  /**
+   * Queues all revisions of a run entity up for file cleanup.
+   */
+  public static function cleanRunEntity($web_page_archive_run) {
+    // Retrieve relevant capture utilities.
+    $web_page_archive = $web_page_archive_run->getConfigEntity();
+    $utilities = $web_page_archive->getCaptureUtilities();
+
+    // Retrieve revision list.
+    $web_page_archive_run_storage = \Drupal::service('entity_type.manager')->getStorage('web_page_archive_run');
+    $vids = $web_page_archive_run_storage->revisionIds($web_page_archive_run);
+
+    // Cleanup all utilities for all revisions.
+    foreach ($utilities as $utility) {
+      foreach ($vids as $vid) {
+        $utility->cleanupRevision($vid);
+      }
+    }
+  }
+
+  /**
+   * Queues a file for deletion.
+   */
+  public static function queueFileDelete($file) {
+    $queue = \Drupal::service('queue')->get('web_page_archive_cleanup');
+    $queue->createItem(['type' => 'file', 'path' => $file]);
+  }
+
+  /**
+   * Processes up to $items_to_process cleanup tasks.
+   */
+  public static function processCleanup($items_to_process) {
+    $queue = \Drupal::service('queue')->get('web_page_archive_cleanup');
+    // If negative, or if count is too high, set count to queue size.
+    if ($items_to_process < 0 || $items_to_process > $queue->numberOfItems()) {
+      $items_to_process = $queue->numberOfItems();
+    }
+    for ($i = 0; $i < $items_to_process; $i++) {
+      static::processCleanupNextItem();
+    }
+  }
+
+  /**
+   * Common batch processing callback for all operations.
+   */
+  private static function processCleanupNextItem() {
+    $queue = \Drupal::service('queue')->get('web_page_archive_cleanup');
+    $queue_worker = \Drupal::service('plugin.manager.queue_worker')->createInstance('web_page_archive_cleanup');
+
+    if ($item = $queue->claimItem()) {
+      try {
+        $processed = $queue_worker->processItem($item->data);
+        if (!isset($processed)) {
+          throw new RequeueException(t('Still Running'));
+        }
+        $queue->deleteItem($item);
+        return TRUE;
+      }
+      catch (RequeueException $e) {
+        $queue->releaseItem($item);
+      }
+      catch (SuspendQueueException $e) {
+        $queue->releaseItem($item);
+        watchdog_exception($e);
+      }
+      catch (\Exception $e) {
+        // In case of any other kind of exception, log it and leave the item
+        // in the queue to be processed again later.
+        watchdog_exception('cron', $e);
+      }
+    }
+
+    return FALSE;
+  }
+
+}

--- a/src/Entity/WebPageArchiveRun.php
+++ b/src/Entity/WebPageArchiveRun.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\RevisionableContentEntityBase;
 use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\UserInterface;
+use Drupal\web_page_archive\Controller\CleanupController;
 
 /**
  * Defines the Web page archive run entity.
@@ -390,5 +391,14 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
     return $fields;
   }
 
-  // TODO: Implement delete() to delete any stored files.
+  /**
+   * {@inheritdoc}
+   */
+  public function delete() {
+    if (!$this->isNew()) {
+      CleanupController::cleanRunEntity($this);
+    }
+    parent::delete();
+  }
+
 }

--- a/src/Plugin/CaptureResponse/UriCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/UriCaptureResponse.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\web_page_archive\Plugin\CaptureResponse;
 
+use Drupal\web_page_archive\Controller\CleanupController;
 use Drupal\web_page_archive\Plugin\CaptureResponseBase;
 
 /**
@@ -39,6 +40,34 @@ class UriCaptureResponse extends CaptureResponseBase {
    */
   public function renderable(array $options = []) {
     return $this->content;
+  }
+
+  /**
+   * Queues all files in the specified revision for deletion.
+   */
+  public static function cleanupRevision($revision_id) {
+    $run_revision = \Drupal::entityManager()
+      ->getStorage('web_page_archive_run')
+      ->loadRevision($revision_id);
+
+    $captures = $run_revision->get('field_captures');
+    foreach ($captures as $capture) {
+      // Skip invalid responses, which indicates there are no files to remove.
+      $value = $capture->getValue();
+      if (empty($value['value'])) {
+        continue;
+      }
+      $unserialized = unserialize($value['value']);
+      if (empty($unserialized['capture_response'])) {
+        continue;
+      }
+
+      // Queue up file for removal.
+      $file = $unserialized['capture_response']->getContent();
+      if (file_exists($file)) {
+        CleanupController::queueFileDelete($file);
+      }
+    }
   }
 
 }

--- a/src/Plugin/CaptureUtilityBase.php
+++ b/src/Plugin/CaptureUtilityBase.php
@@ -149,4 +149,9 @@ abstract class CaptureUtilityBase extends PluginBase implements CaptureUtilityIn
     return [];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function cleanupRevision($revision_id) {}
+
 }

--- a/src/Plugin/CaptureUtilityInterface.php
+++ b/src/Plugin/CaptureUtilityInterface.php
@@ -79,4 +79,12 @@ interface CaptureUtilityInterface extends PluginInspectionInterface, Configurabl
    */
   public function setWeight($weight);
 
+  /**
+   * Performs cleanup on a run entity revision for the capture utility.
+   *
+   * @param int $revision_id
+   *   Specific revision to cleanup.
+   */
+  public function cleanupRevision($revision_id);
+
 }

--- a/src/Plugin/QueueWorker/FileCleanupQueueWorker.php
+++ b/src/Plugin/QueueWorker/FileCleanupQueueWorker.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerBase;
+
+/**
+ * Provides functionality for running capture jobs.
+ *
+ * @QueueWorker(
+ *   id = "web_page_archive_cleanup",
+ *   title = @Translation("Web Page Archive Cleanup"),
+ * )
+ */
+class FileCleanupQueueWorker extends QueueWorkerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    if (file_exists($data['path'])) {
+      if (\Drupal::service('file_system')->unlink($data['path'])) {
+        return TRUE;
+      }
+      else {
+        throw new \Exception(t('Could not delete @file', ['@file' => $file]));
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -386,8 +386,30 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
 
     // Switched to detailed view.
     $this->clickLink('View Details');
-    $file_path = str_replace(['://', ':', '/'], '-', $capture_url);
-    $assert->responseMatches("/<span>.*{$file_path}\.html<\/span>/");
+
+    // Parse file path.
+    if (preg_match('/(\/.*\.html)/', $this->getRawContent(), $matches)) {
+      $file_path = $matches[1];
+    }
+    else {
+      $file_path = 'this-test-will-fail.html';
+    }
+
+    // Assert file exists.
+    $this->assertTrue(file_exists($file_path));
+
+    // Delete the config entity.
+    $this->drupalGet('admin/config/system/web-page-archive/localhost/delete');
+    $this->drupalPostForm(NULL, [], t('Delete'));
+    $assert->pageTextContains(t('content web_page_archive: deleted localhost'));
+    $assert->pageTextContains(t('There is no Web Page Archive yet.'));
+
+    // Simulate a cron run.
+    web_page_archive_cron();
+
+    // Assert file no longer exists.
+    $this->assertFalse(file_exists($file_path));
+
   }
 
 }

--- a/web_page_archive.module
+++ b/web_page_archive.module
@@ -5,6 +5,7 @@
  * This module holds functions useful for web page archives.
  */
 
+use Drupal\web_page_archive\Controller\CleanupController;
 use Drupal\web_page_archive\Entity\WebPageArchiveTypeInfo;
 
 /**
@@ -34,4 +35,7 @@ function web_page_archive_cron() {
   foreach ($config_entities as $id => $config_entity) {
     $cron_runner->run($config_entity);
   }
+
+  // Cleanup files.
+  CleanupController::processCleanup(50);
 }


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2905724

This PR adds a cleanup queue for deleting files after a run entity is deleted. Cleanup is then ran on subsequent cron runs (deleting up to 50 items at a time). 