### PR TITLE
Issue #2907873 by WidgetsBurritos: Ensure URL is properly parsed and sanitized prior to outputting

### DIFF
--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
@@ -4,6 +4,7 @@ namespace Drupal\wpa_screenshot_capture\Plugin\CaptureResponse;
 
 use Drupal\Core\Url;
 use Drupal\Component\Serialization\Json;
+use Drupal\Component\Utility\Html;
 use Drupal\web_page_archive\Plugin\CaptureResponse\UriCaptureResponse;
 
 /**
@@ -32,8 +33,8 @@ class ScreenshotCaptureResponse extends UriCaptureResponse {
 
     // If capture has a URL show it.
     if (!empty($this->captureUrl)) {
-      $url = Url::fromUri($this->captureUrl);
-      $link_array['capture_url'] = ['#markup' => "<p>{$this->captureUrl}</p>"];
+      $url = Html::escape($this->captureUrl);
+      $link_array['capture_url'] = ['#markup' => "<p>{$url}</p>"];
     }
 
     // If capture has a screenshot show it, otherwise show error.


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2907873

This PR sanitizes the capture URL before outputting, on the off chance this can somehow be manipulated. This really seems like a very unlikely scenario, but the extra sanitization here is just a precaution.