### PR TITLE
Issue #2906060 by WidgetsBurritos: Bad items stuck in queue

### DIFF
--- a/src/Controller/WebPageArchiveController.php
+++ b/src/Controller/WebPageArchiveController.php
@@ -113,8 +113,9 @@ class WebPageArchiveController extends ControllerBase {
         watchdog_exception($e);
       }
       catch (\Exception $e) {
-        // In case of any other kind of exception, log it and leave the item
-        // in the queue to be processed again later.
+        // In case of any other kind of exception, log it and remove it from
+        // the queue to prevent queues from getting stuck.
+        $queue->deleteItem($item);
         watchdog_exception('cron', $e);
       }
 


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2906060

This PR fixes the instance where an unknown exception is thrown and an item remains in the queue.  Due to the "continuing" nature of how cron capture jobs work, this means jobs could potentially get stuck in a perpetual running state if for reason an exception is thrown.  

An example of that is if someone attempts capture the URL `bad panda`. The following exception gets thrown:

```
Screen\Exceptions\InvalidUrlException: The url 'http://bad panda' is not valid. in Screen\Injection\Url->__construct() (line 24 of /path/to/drupal/vendor/microweber/screen/src/Injection/Url.php).
```

Another possible failure I've seen is:
```
Screen\Exceptions\PhantomJsException: Unable to load the address! in Screen\Capture->save() (line 259 of /path/to/drupal/vendor/microweber/screen/src/Capture.php).
```

In these scenarios we still want to log the error to cron, but it's imperative to kick the item out of the queue. 