### PR TITLE
Issue #2908497 by WidgetsBurritos, aks22: Gracefully handle composer-less installs

### DIFF
--- a/src/Controller/WebPageArchiveController.php
+++ b/src/Controller/WebPageArchiveController.php
@@ -3,7 +3,9 @@
 namespace Drupal\web_page_archive\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Link;
 use Drupal\Core\Queue\RequeueException;
+use Drupal\Core\Url;
 use Drupal\views\Views;
 use Drupal\web_page_archive\Entity\WebPageArchive;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -139,6 +141,20 @@ class WebPageArchiveController extends ControllerBase {
       ];
       drupal_set_message(t('An error occurred while processing @operation with arguments : @args', $values));
     }
+  }
+
+  /**
+   * Ensures proper dependencies are installed in the system.
+   */
+  public static function checkDependencies() {
+    if (!class_exists('\\Cron\\CronExpression')) {
+      $urlObj = Url::fromUri('https://www.drupal.org/project/web_page_archive#installation');
+      $urlObj->setOptions(['attributes' => ['target' => '_blank']]);
+      $instructions_link = Link::fromTextAndUrl(t('installation instructions'), $urlObj)->toString();
+      \drupal_set_message(t('Missing mtdowling/cron-expression package. Web page archive must be installed via composer. See @instructions for more information.', ['@instructions' => $instructions_link]), 'error');
+      return FALSE;
+    }
+    return TRUE;
   }
 
 }

--- a/src/Entity/WebPageArchiveListBuilder.php
+++ b/src/Entity/WebPageArchiveListBuilder.php
@@ -6,6 +6,7 @@ use Cron\CronExpression;
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
+use Drupal\web_page_archive\Controller\WebPageArchiveController;
 
 /**
  * Provides a listing of Web page archive entity entities.
@@ -16,6 +17,11 @@ class WebPageArchiveListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function load() {
+    // If we're missing dependencies, we shouldn't display any results.
+    if (!WebPageArchiveController::checkDependencies()) {
+      return [];
+    }
+
     $capture_utilities = \Drupal::service('plugin.manager.capture_utility')->getDefinitions();
     if (empty($capture_utilities)) {
       $url = Url::fromRoute('system.modules_list', [], ['fragment' => 'edit-modules-web-page-archive']);

--- a/src/Form/WebPageArchiveAddForm.php
+++ b/src/Form/WebPageArchiveAddForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\web_page_archive\Form;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\web_page_archive\Controller\WebPageArchiveController;
 
 /**
  * Class WebPageArchiveAddForm.
@@ -25,6 +26,11 @@ class WebPageArchiveAddForm extends WebPageArchiveFormBase {
    * {@inheritdoc}
    */
   public function actions(array $form, FormStateInterface $form_state) {
+    // If we're missing dependencies, we shouldn't have a save button.
+    if (!WebPageArchiveController::checkDependencies()) {
+      return [];
+    }
+
     $actions = parent::actions($form, $form_state);
     $actions['submit']['#value'] = $this->t('Create new archive');
 

--- a/src/Form/WebPageArchiveEditForm.php
+++ b/src/Form/WebPageArchiveEditForm.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\web_page_archive\Controller\WebPageArchiveController;
 use Drupal\web_page_archive\Plugin\CaptureUtilityManager;
 use Drupal\web_page_archive\Plugin\ConfigurableCaptureUtilityInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -254,6 +255,11 @@ class WebPageArchiveEditForm extends WebPageArchiveFormBase {
    * {@inheritdoc}
    */
   public function actions(array $form, FormStateInterface $form_state) {
+    // If we're missing dependencies, we shouldn't have a save button.
+    if (!WebPageArchiveController::checkDependencies()) {
+      return [];
+    }
+
     $actions = parent::actions($form, $form_state);
     $actions['submit']['#value'] = $this->t('Update archive');
 

--- a/src/Form/WebPageArchiveFormBase.php
+++ b/src/Form/WebPageArchiveFormBase.php
@@ -6,6 +6,7 @@ use Cron\CronExpression;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\web_page_archive\Controller\WebPageArchiveController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -50,6 +51,10 @@ abstract class WebPageArchiveFormBase extends EntityForm {
    * {@inheritdoc}
    */
   public function form(array $form, FormStateInterface $form_state) {
+    // If we're missing dependencies, we shouldn't have any form fields.
+    if (!WebPageArchiveController::checkDependencies()) {
+      return [];
+    }
 
     $form['label'] = [
       '#type' => 'textfield',


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2908497

This PR handles composer-less installs a little more gracefully. Basically, instead of an ugly error message, we make use of `\drupal_set_message()` to provide some information on how to install properly.