### PR TITLE
Issue #2911488 by WidgetsBurritos: Set sensible screenshot capture utility defaults

### DIFF
--- a/drupal_ti/before/before_script.sh
+++ b/drupal_ti/before/before_script.sh
@@ -13,4 +13,4 @@ drupal_ti_ensure_drupal
 # Change to the Drupal directory
 cd "$DRUPAL_TI_DRUPAL_DIR"
 
-composer require "mtdowling/cron-expression:1.2.0"
+composer require "mtdowling/cron-expression:1.2.0" "microweber/screen:1.0.*"

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -123,7 +123,7 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       '#title' => $this->t('Image type'),
       '#options' => $image_types,
       '#empty_option' => $this->t('Select an image type'),
-      '#default_value' => isset($this->configuration['image_type']) ? $this->configuration['image_type'] : '',
+      '#default_value' => isset($this->configuration['image_type']) ? $this->configuration['image_type'] : 'png',
       '#required' => TRUE,
     ];
     $form['background_color'] = [
@@ -136,7 +136,7 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       '#type' => 'textfield',
       '#title' => $this->t('Browser user agent'),
       '#description' => $this->t('Specify the browser user agent. e.g. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"'),
-      '#default_value' => isset($this->configuration['user_agent']) ? $this->configuration['user_agent'] : '',
+      '#default_value' => isset($this->configuration['user_agent']) ? $this->configuration['user_agent'] : $this->t('WPA'),
     ];
 
     return $form;

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -102,6 +102,62 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('url_type', 'sitemap');
     $this->assertFieldByName('urls', 'http://localhost/sitemap.xml');
 
+    // Add a screenshot capture utility.
+    $this->drupalPostForm(
+      NULL,
+      [
+        'new' => 'wpa_screenshot_capture',
+      ],
+      t('Add')
+    );
+
+    // Check field default values.
+    $this->assertFieldByName('data[width]', '1280');
+    $this->assertFieldByName('data[clip_width]', '1280');
+    $this->assertFieldByName('data[image_type]', 'png');
+    $this->assertFieldByName('data[background_color]', '#ffffff');
+    $this->assertFieldByName('data[user_agent]', 'WPA');
+
+    // Alter a few values and then submit.
+    $this->drupalPostForm(
+      NULL,
+      [
+        'data[width]' => '1400',
+        'data[image_type]' => 'jpg',
+      ],
+      t('Add capture utility')
+    );
+
+    // Open capture utility settings.
+    $this->clickLink('Edit');
+
+    // Confirm field values.
+    $this->assertFieldByName('data[width]', '1400');
+    $this->assertFieldByName('data[clip_width]', '1280');
+    $this->assertFieldByName('data[image_type]', 'jpg');
+    $this->assertFieldByName('data[background_color]', '#ffffff');
+    $this->assertFieldByName('data[user_agent]', 'WPA');
+
+    // Attempt to change user agent and image type.
+    $this->drupalPostForm(
+      NULL,
+      [
+        'data[image_type]' => 'png',
+        'data[user_agent]' => 'Testbot 5000',
+      ],
+      t('Update capture utility')
+    );
+
+    // Open capture utility settings.
+    $this->clickLink('Edit');
+
+    // Confirm field values.
+    $this->assertFieldByName('data[width]', '1400');
+    $this->assertFieldByName('data[clip_width]', '1280');
+    $this->assertFieldByName('data[image_type]', 'png');
+    $this->assertFieldByName('data[background_color]', '#ffffff');
+    $this->assertFieldByName('data[user_agent]', 'Testbot 5000');
+
     // Confirm entity list shows next scheduled time.
     $this->drupalGet('admin/config/system/web-page-archive');
     $assert->pageTextContains(t('-01-01 @ 9:00am'));


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2911488

This PR adds sensible to defaults to the screenshot capture utility form, and expands test coverage to confirm saving capture utility settings in the UI works properly. 

Note: Adding `"microweber/screen:1.0.*"` to `drupal_ti/before/before_script.sh` is purely so Travis can run tests properly.