### PR TITLE
chore(travis): Set default branch to 8.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
 
     # The environment to use, supported are: drupal-7, drupal-8
     - DRUPAL_TI_ENVIRONMENT="drupal-8"
-    - DRUPAL_TI_CORE_BRANCH="8.3.x"
+    - DRUPAL_TI_CORE_BRANCH="8.4.x"
 
     # The installation profile to use:
     #- DRUPAL_TI_INSTALL_PROFILE="testing"


### PR DESCRIPTION
This PR is simply to test what happens when we set Travis's default branch to 8.4.x instead of 8.3.x