### PR TITLE
Issue #2911746 by bapi_22, WidgetsBurritos: entityManager and entityQuery is deprecated now

### DIFF
--- a/src/Controller/PrepareUninstallController.php
+++ b/src/Controller/PrepareUninstallController.php
@@ -15,8 +15,8 @@ class PrepareUninstallController extends ControllerBase {
    * Deletes web_page_archive subscribers.
    */
   public static function deleteRunEntities(&$context) {
-    $run_ids = \Drupal::entityQuery('web_page_archive_run')->range(0, 100)->execute();
-    $storage = \Drupal::entityManager()->getStorage('web_page_archive_run');
+    $storage = \Drupal::entityTypeManager()->getStorage('web_page_archive_run');
+    $run_ids = $storage->getQuery()->range(0, 100)->execute();
     if ($run = $storage->loadMultiple($run_ids)) {
       $storage->delete($run);
     }

--- a/src/Controller/WebPageArchiveRunController.php
+++ b/src/Controller/WebPageArchiveRunController.php
@@ -27,8 +27,8 @@ class WebPageArchiveRunController extends ControllerBase implements ContainerInj
    *   An array suitable for drupal_render().
    */
   public function revisionShow($web_page_archive_run_revision) {
-    $web_page_archive_run = $this->entityManager()->getStorage('web_page_archive_run')->loadRevision($web_page_archive_run_revision);
-    $view_builder = $this->entityManager()->getViewBuilder('web_page_archive_run');
+    $web_page_archive_run = $this->entityTypeManager()->getStorage('web_page_archive_run')->loadRevision($web_page_archive_run_revision);
+    $view_builder = $this->entityTypeManager()->getViewBuilder('web_page_archive_run');
 
     return $view_builder->view($web_page_archive_run);
   }
@@ -43,7 +43,7 @@ class WebPageArchiveRunController extends ControllerBase implements ContainerInj
    *   The page title.
    */
   public function revisionPageTitle($web_page_archive_run_revision) {
-    $web_page_archive_run = $this->entityManager()->getStorage('web_page_archive_run')->loadRevision($web_page_archive_run_revision);
+    $web_page_archive_run = $this->entityTypeManager()->getStorage('web_page_archive_run')->loadRevision($web_page_archive_run_revision);
     return $this->t('Revision of %title from %date', ['%title' => $web_page_archive_run->label(), '%date' => format_date($web_page_archive_run->getRevisionCreationTime())]);
   }
 
@@ -62,7 +62,7 @@ class WebPageArchiveRunController extends ControllerBase implements ContainerInj
     $langname = $web_page_archive_run->language()->getName();
     $languages = $web_page_archive_run->getTranslationLanguages();
     $has_translations = (count($languages) > 1);
-    $web_page_archive_run_storage = $this->entityManager()->getStorage('web_page_archive_run');
+    $web_page_archive_run_storage = $this->entityTypeManager()->getStorage('web_page_archive_run');
 
     $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', ['@langname' => $langname, '%title' => $web_page_archive_run->label()]) : $this->t('Revisions for %title', ['%title' => $web_page_archive_run->label()]);
     $header = [$this->t('Revision'), $this->t('Operations')];

--- a/src/Form/WebPageArchiveEditForm.php
+++ b/src/Form/WebPageArchiveEditForm.php
@@ -44,7 +44,7 @@ class WebPageArchiveEditForm extends WebPageArchiveFormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity.manager')->getStorage('web_page_archive'),
+      $container->get('entity_type.manager')->getStorage('web_page_archive'),
       $container->get('plugin.manager.capture_utility')
     );
   }

--- a/src/Form/WebPageArchiveFormBase.php
+++ b/src/Form/WebPageArchiveFormBase.php
@@ -43,7 +43,7 @@ abstract class WebPageArchiveFormBase extends EntityForm {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity.manager')->getStorage('web_page_archive')
+      $container->get('entity_type.manager')->getStorage('web_page_archive')
     );
   }
 

--- a/src/Form/WebPageArchiveRunRevisionDeleteForm.php
+++ b/src/Form/WebPageArchiveRunRevisionDeleteForm.php
@@ -55,7 +55,7 @@ class WebPageArchiveRunRevisionDeleteForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    $entity_manager = $container->get('entity.manager');
+    $entity_manager = $container->get('entity_type.manager');
     return new static(
       $entity_manager->getStorage('web_page_archive_run'),
       $container->get('database')

--- a/src/Plugin/CaptureResponse/UriCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/UriCaptureResponse.php
@@ -46,7 +46,7 @@ class UriCaptureResponse extends CaptureResponseBase {
    * Queues all files in the specified revision for deletion.
    */
   public static function cleanupRevision($revision_id) {
-    $run_revision = \Drupal::entityManager()
+    $run_revision = \Drupal::entityTypeManager()
       ->getStorage('web_page_archive_run')
       ->loadRevision($revision_id);
 

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -235,7 +235,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
         ],
       ],
     ];
-    $wpa = \Drupal::entityManager()
+    $wpa = \Drupal::entityTypeManager()
       ->getStorage('web_page_archive')
       ->create($data);
     $wpa->save();
@@ -273,7 +273,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
       'url_type' => 'sitemap',
       'urls' => 'http://localhost/sitemap.xml',
     ];
-    $wpa = \Drupal::entityManager()
+    $wpa = \Drupal::entityTypeManager()
       ->getStorage('web_page_archive')
       ->create($data);
     $wpa->save();
@@ -317,7 +317,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
       'url_type' => 'sitemap',
       'urls' => 'http://localhost/sitemap.xml',
     ];
-    $wpa = \Drupal::entityManager()
+    $wpa = \Drupal::entityTypeManager()
       ->getStorage('web_page_archive')
       ->create($data);
     $wpa->save();
@@ -374,7 +374,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
         ],
       ],
     ];
-    $wpa = \Drupal::entityManager()
+    $wpa = \Drupal::entityTypeManager()
       ->getStorage('web_page_archive')
       ->create($data);
     $wpa->save();


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2911746

This PR is simply to test the patch from the drupal issue, since one of my previous changes broke testing on drupal.org