### PR TITLE
Issue #2905911 by WidgetsBurritos: Human-friendly capture sizes

### DIFF
--- a/config/install/views.view.web_page_archive_canonical.yml
+++ b/config/install/views.view.web_page_archive_canonical.yml
@@ -409,12 +409,8 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: number_decimal
-          settings:
-            thousand_separator: ','
-            prefix_suffix: true
-            decimal_separator: .
-            scale: 0
+          type: wpa_capture_size
+          settings: {  }
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/src/Plugin/Field/FieldFormatter/CaptureSizeFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/CaptureSizeFormatter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Formatter the capture size in a human readable way.
+ *
+ * @FieldFormatter(
+ *   id = "wpa_capture_size",
+ *   label = @Translation("Capture size"),
+ *   field_types = {
+ *     "integer",
+ *     "float"
+ *   }
+ * )
+ */
+class CaptureSizeFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $elements[$delta] = ['#markup' => format_size($item->value)];
+    }
+
+    return $elements;
+  }
+
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -122,3 +122,17 @@ function web_page_archive_update_8002() {
     $query->execute();
   }
 }
+
+/**
+ * Sets the formatter for the capture size field.
+ */
+function web_page_archive_update_8003() {
+  $view = 'views.view.web_page_archive_canonical';
+  $config_key = 'display.default.display_options.fields.capture_size.type';
+  $view_config = \Drupal::service('config.factory')->getEditable($view);
+  $current_value = $view_config->get($config_key);
+  if ($config_key !== 'wpa_capture_size') {
+    $view_config->set($config_key, 'wpa_capture_size');
+    $view_config->save();
+  }
+}


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2905911

This PR adds a capture size formatter. 

I spent a lot of time trying to get the `Drupal\file\Plugin\Field\FieldFormatter\FileSize` formatter to work with this, but it relies on a few things:

1.) The field type to be `integer`.  Currently I'm using `float`.
2.) The field name has to be `filesize`. 

This formatter seems pretty strict on a lot of database aspects, that kind of defeat the purpose of a formatter in my mind.  As such, I just created a new capture size formatter that mimics the FileSize formatter, but allows it to work with any field name and supports `float` fields. 