### PR TITLE
 Issue #2901784 by WidgetsBurritos: Setup HTML capture rendering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "minimum-stability": "dev",
     "require": {
         "mtdowling/cron-expression": "1.2.0",
-        "t1gor/robots-txt-parser": "0.2.3"
+        "t1gor/robots-txt-parser": "0.2.3",
+        "kukulich/fshl": "2.1.0"
     },
     "require-dev": {
         "microweber/screen": "1.0.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2404c0d876b0a25961796bafdd140443",
+    "content-hash": "ed784694b92a0ac08cd2a54c97e3eaa8",
     "packages": [
+        {
+            "name": "kukulich/fshl",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kukulich/fshl.git",
+                "reference": "974c294ade5d76c0c16b6fe3fd3a584ba999b24f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kukulich/fshl/zipball/974c294ade5d76c0c16b6fe3fd3a584ba999b24f",
+                "reference": "974c294ade5d76c0c16b6fe3fd3a584ba999b24f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "FSHL": "./"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Jaroslav Hanslík",
+                    "homepage": "https://github.com/kukulich"
+                }
+            ],
+            "description": "FSHL is a free, open source, universal, fast syntax highlighter written in PHP.",
+            "homepage": "http://fshl.kukulich.cz/",
+            "keywords": [
+                "highlight",
+                "library",
+                "syntax"
+            ],
+            "time": "2012-09-08T19:00:07+00:00"
+        },
         {
             "name": "mtdowling/cron-expression",
             "version": "v1.2.0",

--- a/css/web_page_archive.admin.css
+++ b/css/web_page_archive.admin.css
@@ -9,3 +9,12 @@
 .image-style-web-page-archive-full {
   max-width: 100%;
 }
+
+.wpa-hidden {
+  display: none;
+}
+
+.wpa-code-window {
+  background: #f0f0f0;
+  padding: 15px;
+}

--- a/css/web_page_archive.fshl.css
+++ b/css/web_page_archive.fshl.css
@@ -1,0 +1,280 @@
+/**
+ * FSHL 2.1.0                                  | Fast Syntax HighLighter |
+ * -----------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This program is free software
+  you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation
+  either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY
+  without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+/* Copyright (c) 2002 Martin Cohen */
+/* Copyright (c) 2011-2012 Jaroslav Hanslík */
+
+/* Common */
+.xlang {
+  color: #ff0000;
+  font-weight: bold;
+}
+.line {
+  color: #000000;
+  background-color: #ffffff;
+}
+
+/* CSS */
+.css-at-rule {
+  color: #004a80;
+  font-weight: bold;
+}
+.css-tag {
+  color: #004a80;
+}
+.css-id {
+  color: #7da7d9;
+  font-weight: bold;
+}
+.css-class {
+  color: #004a80;
+}
+.css-pseudo {
+  color: #004a80;
+}
+.css-property {
+  color: #003663;
+  font-weight: bold;
+}
+.css-value {
+  color: #448ccb;
+}
+.css-func {
+  color: #448ccb;
+  font-weight: bold;
+}
+.css-color {
+  color: #0076a3;
+}
+.css-comment {
+  background-color: #e5f8ff;
+  color: #999999;
+}
+
+/* CPP */
+.cpp-keywords1 {
+  color: #0000ff;
+  font-weight: bold;
+}
+.cpp-num {
+  color: #ff0000;
+}
+.cpp-quote {
+  color: #a52a2a;
+  font-weight: bold;
+}
+.cpp-comment {
+  color: #00ff00;
+}
+.cpp-preproc {
+  color: #c0c0c0;
+}
+
+/* HTML */
+.html-tag {
+  color: #598527;
+  font-weight: bold;
+}
+.html-tagin {
+  color: #89a315;
+}
+.html-quote {
+  color: #598527;
+  font-weight: bold;
+}
+.html-comment {
+  color: #999999;
+  background-color: #f1fae4;
+}
+.html-entity {
+  color: #89a315;
+}
+
+/* Java */
+.java-keywords1 {
+  color: #0000ff;
+  font-weight: bold;
+}
+.java-num {
+  color: #ff0000;
+}
+.java-quote {
+  color: #a52a2a;
+  font-weight: bold;
+}
+.java-comment {
+  color: #009900;
+}
+.java-preproc {
+  color: #c0c0c0;
+}
+
+/* Javascript */
+.js-out {
+  color: #898993;
+}
+.js-keywords1 {
+  color: #575757;
+  font-weight: bold;
+}
+.js-num {
+  color: #575757;
+}
+.js-quote {
+  color: #575757;
+  font-weight: bold;
+}
+.js-comment {
+  color: #898993;
+  background-color: #f4f4f4;
+}
+
+/* Neon */
+.neon-section {
+  color: #598527;
+}
+.neon-sep {
+  color: #ff0000;
+}
+.neon-key {
+  color: #0000ff;
+}
+.neon-comment {
+  color: #999999;
+}
+.neon-value {
+  color: #000000;
+}
+.neon-quote {
+  color: #884433;
+}
+.neon-num {
+  color: #448ccb;
+}
+.neon-var {
+  color: #ffaa00;
+}
+.neon-ref {
+  color: #884433;
+}
+
+/* PHP */
+.php-keyword1 {
+  color: #dd2244;
+  font-weight: bold;
+}
+.php-keyword2 {
+  color: #dd2244;
+}
+.php-var {
+  color: #ffaa00;
+  font-weight: bold;
+}
+.php-num {
+  color: #ff0000;
+}
+.php-quote {
+  color: #884433;
+  font-weight: bold;
+}
+.php-comment {
+  color: #999999;
+  background-color: #ffffee;
+}
+
+/* Python */
+.py-keyword1 {
+  color: #0033cc;
+  font-weight: bold;
+}
+.py-keyword2 {
+  color: #ce3333;
+  font-weight: bold;
+}
+.py-keyword3 {
+  color: #660066;
+  font-weight: bold;
+}
+.py-num {
+  color: #993300;
+}
+.py-docstring {
+  color: #e86a18;
+}
+.py-quote {
+  color: #878787;
+  font-weight: bold;
+}
+.py-comment {
+  color: #009900;
+  font-style: italic;
+}
+
+/* SQL */
+.sql-keyword1 {
+  color: #dd0000;
+  font-weight: bold;
+}
+.sql-keyword2 {
+  color: #dd2222;
+}
+.sql-keyword3 {
+  color: #0000ff;
+  font-weight: bold;
+}
+.sql-value {
+  color: #5674b9;
+}
+.sql-comment {
+  color: #ffaa00;
+}
+.sql-num {
+  color: #ff0000;
+}
+.sql-option {
+  color: #004a80;
+  font-weight: bold;
+}
+
+/* Texy */
+.texy-hlead {
+  color: #4444bb;
+  font-weight: bold;
+}
+.texy-hbody {
+  background-color: #eeeeff;
+  color: #4444bb;
+}
+.texy-hr {
+  color: #bb4444;
+}
+.texy-code {
+  color: #666666;
+}
+.texy-html {
+  color: #66aa66;
+}
+.texy-text {
+  color: #6666aa;
+}
+.texy-err {
+  background-color: #ff0000;
+  color: #ffffff;
+}

--- a/drupal_ti/before/before_script.sh
+++ b/drupal_ti/before/before_script.sh
@@ -13,4 +13,7 @@ drupal_ti_ensure_drupal
 # Change to the Drupal directory
 cd "$DRUPAL_TI_DRUPAL_DIR"
 
-composer require "mtdowling/cron-expression:1.2.0" "microweber/screen:1.0.*" "t1gor/robots-txt-parser:0.2.3"
+composer require "mtdowling/cron-expression:1.2.0"\
+  "microweber/screen:1.0.*"\
+  "t1gor/robots-txt-parser:0.2.3"\
+  "kukulich/fshl:2.1.0"

--- a/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\wpa_html_capture\Plugin\CaptureResponse;
+
+use Drupal\Core\Url;
+use Drupal\Component\Serialization\Json;
+use Drupal\Component\Utility\Html;
+use Drupal\web_page_archive\Plugin\CaptureResponse\UriCaptureResponse;
+use FSHL\Highlighter;
+use FSHL\Output\Html as OutputHtml;
+use FSHL\Lexer\Html as LexerHtml;
+
+/**
+ * URI capture response.
+ */
+class HtmlCaptureResponse extends UriCaptureResponse {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderable(array $options = []) {
+    return (isset($options['mode']) && $options['mode'] == 'full') ?
+      $this->renderFull($options) : $this->renderPreview($options);
+  }
+
+  /**
+   * Renders "preview" mode.
+   */
+  private function renderPreview(array $options) {
+    $link_array = [];
+
+    $route_params = [
+      'web_page_archive_run_revision' => $options['vid'],
+      'delta' => $options['delta'],
+    ];
+
+    // If capture has a URL show it.
+    if (!empty($this->captureUrl)) {
+      $url = Html::escape($this->captureUrl);
+      $link_array['capture_url'] = ['#markup' => "<p>{$url}</p>"];
+    }
+
+    $render['link'] = [
+      '#type' => 'link',
+      '#url' => Url::fromRoute('entity.web_page_archive.modal', $route_params),
+      '#title' => $link_array,
+      '#markup' => 'body',
+      '#attributes' => [
+        'class' => ['use-ajax'],
+        'data-dialog-type' => 'modal',
+        // TODO: Pull this value from config?
+        'data-dialog-options' => Json::encode(['width' => 1024]),
+      ],
+    ];
+
+    $render['path'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'span',
+      '#attributes' => [
+        'class' => ['wpa-hidden', 'wpa-file-path'],
+      ],
+      '#value' => $this->content,
+    ];
+
+    $render['#attached'] = ['library' => ['web_page_archive/admin']];
+
+    return $render;
+  }
+
+  /**
+   * Renders full mode.
+   */
+  private function renderFull(array $options) {
+    // If capture has a screenshot show it, otherwise show error.
+    if (!empty($this->content)) {
+      $file = file_get_contents($this->content);
+      $highlighter = new Highlighter(new OutputHtml());
+      $highlighter->setLexer(new LexerHtml());
+
+      return [
+        '#prefix' => '<pre class="wpa-code-window">',
+        // TODO: Evaluate security of highlighter via tests.
+        // @see https://www.drupal.org/node/2907876
+        '#markup' => $highlighter->highlight($file),
+        '#suffix' => '</pre>',
+        '#attached' => ['library' => ['web_page_archive/fshl']],
+      ];
+    }
+
+    return ['#markup' => $this->t('There was a problem generating this capture.')];
+  }
+
+}

--- a/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -79,8 +79,6 @@ class HtmlCaptureResponse extends UriCaptureResponse {
 
       return [
         '#prefix' => '<pre class="wpa-code-window">',
-        // TODO: Evaluate security of highlighter via tests.
-        // @see https://www.drupal.org/node/2907876
         '#markup' => $highlighter->highlight($file),
         '#suffix' => '</pre>',
         '#attached' => ['library' => ['web_page_archive/fshl']],

--- a/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -3,8 +3,8 @@
 namespace Drupal\wpa_html_capture\Plugin\CaptureUtility;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\web_page_archive\Plugin\CaptureResponse\UriCaptureResponse;
 use Drupal\web_page_archive\Plugin\ConfigurableCaptureUtilityBase;
+use Drupal\wpa_html_capture\Plugin\CaptureResponse\HtmlCaptureResponse;
 
 /**
  * Captures HTML of a remote uri.
@@ -33,8 +33,8 @@ class HtmlCaptureUtility extends ConfigurableCaptureUtilityBase {
       throw new \Exception('Capture URL is required');
     }
 
-    $file_path = \Drupal::service('file_system')->realpath(file_default_scheme() . "://");
-    $save_dir = "{$file_path}/web-page-archive/html/{$data['web_page_archive']->id()}/{$data['run_uuid']}";
+    $file_path = file_default_scheme() . "://";
+    $save_dir = "{$file_path}web-page-archive/html/{$data['web_page_archive']->id()}/{$data['run_uuid']}";
     $file_name = preg_replace('/[^a-z0-9]+/', '-', strtolower($data['url'])) . '.html';
     $file_location = "{$save_dir}/{$file_name}";
 
@@ -44,7 +44,7 @@ class HtmlCaptureUtility extends ConfigurableCaptureUtilityBase {
 
     \Drupal::httpClient()->request('GET', $data['url'], ['sink' => $file_location]);
 
-    $this->response = new UriCaptureResponse($file_location, $data['url']);
+    $this->response = new HtmlCaptureResponse($file_location, $data['url']);
 
     return $this;
   }
@@ -91,7 +91,7 @@ class HtmlCaptureUtility extends ConfigurableCaptureUtilityBase {
    * {@inheritdoc}
    */
   public function cleanupRevision($revision_id) {
-    UriCaptureResponse::cleanupRevision($revision_id);
+    HtmlCaptureResponse::cleanupRevision($revision_id);
   }
 
 }

--- a/modules/wpa_html_capture/wpa_html_capture.install
+++ b/modules/wpa_html_capture/wpa_html_capture.install
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @file
+ * Install commands for wpa_html_capture.
+ */
+
+use Drupal\wpa_html_capture\Plugin\CaptureResponse\HtmlCaptureResponse;
+
+/**
+ * Convert UriCaptureResponses to HtmlCaptureResponses.
+ */
+function wpa_html_capture_update_8001(&$sandbox = NULL) {
+  $entity_limit = 1;
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $run_storage = $entity_type_manager->getStorage('web_page_archive_run');
+
+  if (!array_key_exists('max', $sandbox)) {
+    $sandbox['max'] = $run_storage->getQuery()
+      ->condition('capture_utilities', '%wpa_html_capture%', 'LIKE')
+      ->count()
+      ->execute();
+    $sandbox['progress'] = 0;
+    $sandbox['last_processed'] = 0;
+  }
+
+  // Retrieve next $limit run entities.
+  $run_ids = $run_storage->getQuery()
+    ->condition('capture_utilities', '%wpa_html_capture%', 'LIKE')
+    ->range(0, $entity_limit)
+    ->execute();
+
+  // Load and iterate through all runs.
+  if ($runs = $run_storage->loadMultiple($run_ids)) {
+
+    // Determine file paths for replacement.
+    $old_file_path = \Drupal::service('file_system')->realpath(file_default_scheme() . "://") . '/';
+    $new_file_path = file_default_scheme() . "://";
+
+    foreach ($runs as $run) {
+
+      // Iterate through each run revision.
+      $vids = $run_storage->revisionIds($run);
+
+      foreach ($vids as $vid) {
+        $revision = $run_storage->loadRevision($vid);
+        $captures = $revision->get('field_captures');
+
+        // Iterate through each capture and update response type.
+        foreach ($captures as $capture) {
+          // Skip invalid responses.
+          $value = $capture->getValue();
+          if (empty($value['value'])) {
+            continue;
+          }
+          $unserialized = unserialize($value['value']);
+          if (empty($unserialized['capture_response'])) {
+            continue;
+          }
+
+          // Determine if old response is a UriCaptureResponse.
+          $old_response = $unserialized['capture_response'];
+          if (get_class($old_response) == 'Drupal\web_page_archive\Plugin\CaptureResponse\UriCaptureResponse') {
+            // Swap absolute file path out with scheme-based path.
+            $content = str_replace($old_file_path, $new_file_path, $old_response->getContent());
+            $capture_url = $old_response->getCaptureUrl();
+            $unserialized['capture_response'] = new HtmlCaptureResponse($content, $capture_url);
+            $new_value = serialize($unserialized);
+            $capture->setValue($new_value);
+          }
+        }
+
+        // Save changes to our revision.
+        $revision->save();
+      }
+
+      // Update our progress.
+      $sandbox['progress']++;
+    }
+  }
+
+  // Update status message.
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+  if ($sandbox['#finished']) {
+    $message = \Drupal::service('string_translation')->formatPlural($sandbox['progress'], 'Updated 1 web page archive run', 'Updated @count web page archive runs');
+    \drupal_set_message($message, 'status');
+  }
+
+}

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -467,7 +467,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->clickLink('View Details');
 
     // Parse file path.
-    if (preg_match_all('/(\/.*\.html)/', $this->getRawContent(), $matches)) {
+    if (preg_match_all('/<span class="wpa-hidden wpa-file-path">(.*\.html)<\/span>/', $this->getRawContent(), $matches)) {
       $file_path = $matches[1][0];
 
       // Despite attempting to capture two URLs we should only capture 1 due

--- a/tests/src/Unit/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
+++ b/tests/src/Unit/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CaptureResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\wpa_html_capture\Plugin\CaptureResponse\HtmlCaptureResponse;
+
+/**
+ * @coversDefaultClass \Drupal\wpa_html_capture\Plugin\CaptureResponse\HtmlCaptureResponse
+ *
+ * @group web_page_archive
+ */
+class HtmlCaptureResponseTest extends UnitTestCase {
+
+  /**
+   * Test basic methods work as expected.
+   */
+  public function testBasicMethodsWorkCorrectly() {
+    $response = new HtmlCaptureResponse('/some/path/to/file.html', 'http://www.somesite.com');
+
+    // Test getters.
+    $this->assertSame('uri', $response->getType());
+    $this->assertSame('/some/path/to/file.html', $response->getContent());
+
+    // Test serialized output.
+    $expected_serialized = serialize([
+      'type' => 'uri',
+      'content' => '/some/path/to/file.html',
+    ]);
+    $this->assertSame($expected_serialized, $response->getSerialized());
+  }
+
+  /**
+   * Test that HTML content is properly escaped.
+   */
+  public function testRenderedContentIsEscaped() {
+    $file = tempnam('/tmp', 'wpa_');
+    file_put_contents($file, '<p>Some HTML here</p>');
+    $response = new HtmlCaptureResponse($file, 'https://www.whatever.com');
+    $render_array = $response->renderable(['mode' => 'full']);
+    $this->assertSame('<span class="html-tag">&lt;p&gt;</span>Some HTML here<span class="html-tag">&lt;/p&gt;</span>', $render_array['#markup']);
+    unlink($file);
+  }
+
+}

--- a/web_page_archive.libraries.yml
+++ b/web_page_archive.libraries.yml
@@ -3,3 +3,4 @@ admin:
   css:
     theme:
       css/web_page_archive.admin.css: {}
+      css/web_page_archive.fshl.css: {}


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2901784


This PR attempts cleanup the display of HTML captures. 
This is dependent on #56, which must get merged in first. 

This is a incrementally improved experience for HTML captures. Preview of what it looks like: 
![image](https://user-images.githubusercontent.com/5263371/31140373-d32ecc52-a839-11e7-8b8a-c44fd44c2ba0.png)
![image](https://user-images.githubusercontent.com/5263371/31140375-d59fc2f2-a839-11e7-917d-2fa83876e6e5.png)

We may want to iterate on this further in the future, but for now I think this is sufficient for a beta release. 

I also included the security test from https://www.drupal.org/node/2907876 here as a separate commit, as it's related to functionality introduced here. 