### PR TITLE
Issue #2913374 by WidgetsBurritos: Move user agent to base config entity

### DIFF
--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -16,6 +16,9 @@ web_page_archive.web_page_archive.*:
     urls:
       type: string
       label: 'URLs'
+    user_agent:
+      type: string
+      label: 'User Agent'
     use_robots:
       type: boolean
       label: 'Honor robots.txt restrictions'

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -44,8 +44,8 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       $screenCapture->setBackgroundColor($this->configuration['background_color']);
     }
     $screenCapture->setImageType($this->configuration['image_type']);
-    if (!empty($this->configuration['user_agent'])) {
-      $screenCapture->setUserAgentString($this->configuration['user_agent']);
+    if (!empty($data['user_agent'])) {
+      $screenCapture->setUserAgentString($data['user_agent']);
     }
 
     // Determine file locations.
@@ -132,12 +132,6 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       '#description' => $this->t('Specify the browser background color in hexidecimal format. e.g. "#ffffff"'),
       '#default_value' => isset($this->configuration['background_color']) ? $this->configuration['background_color'] : '#ffffff',
     ];
-    $form['user_agent'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Browser user agent'),
-      '#description' => $this->t('Specify the browser user agent. e.g. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"'),
-      '#default_value' => isset($this->configuration['user_agent']) ? $this->configuration['user_agent'] : $this->t('WPA'),
-    ];
 
     return $form;
   }
@@ -151,7 +145,6 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
     $this->configuration['width'] = $form_state->getValue('width');
     $this->configuration['clip_width'] = $form_state->getValue('clip_width');
     $this->configuration['background_color'] = $form_state->getValue('background_color');
-    $this->configuration['user_agent'] = $form_state->getValue('user_agent');
     $this->configuration['image_type'] = $form_state->getValue('image_type');
   }
 

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -53,6 +53,7 @@ use GuzzleHttp\HandlerStack;
  *     "urls",
  *     "use_robots",
  *     "use_cron",
+ *     "user_agent",
  *     "cron_schedule",
  *     "capture_utilities",
  *     "run_entity"
@@ -164,6 +165,13 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
    */
   public function getUseRobots() {
     return $this->use_robots;
+  }
+
+  /**
+   * Indicates user agent used during crawling.
+   */
+  public function getUserAgent() {
+    return $this->user_agent;
   }
 
   /**
@@ -318,7 +326,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
       }
 
       if ($this->getUseRobots()) {
-        $urls = $this->robotsValidator()->filterUrls($urls);
+        $urls = $this->robotsValidator()->filterUrls($urls, $this->getUserAgent());
       }
 
       $queue = $this->getQueue();
@@ -329,6 +337,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
 
       $run_uuid = $this->uuidGenerator()->generate();
       $run_entity = $this->getRunEntity();
+      $user_agent = $this->getUserAgent();
 
       foreach ($urls as $url) {
         foreach ($this->getCaptureUtilities() as $utility) {
@@ -338,6 +347,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
             'url' => $url,
             'run_uuid' => $run_uuid,
             'run_entity' => $run_entity,
+            'user_agent' => $user_agent,
           ];
           $queue->createItem($item);
         }

--- a/src/Form/WebPageArchiveFormBase.php
+++ b/src/Form/WebPageArchiveFormBase.php
@@ -157,6 +157,13 @@ abstract class WebPageArchiveFormBase extends EntityForm {
       ],
     ];
 
+    $form['user_agent'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Browser user agent'),
+      '#description' => $this->t('Specify the browser user agent. e.g. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"'),
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getUserAgent() : $this->t('WPA'),
+    ];
+
     $form['urls'] = [
       '#type' => 'textarea',
       '#title' => $this->t('URLs to Capture'),

--- a/src/Plugin/QueueWorker/CaptureQueueWorker.php
+++ b/src/Plugin/QueueWorker/CaptureQueueWorker.php
@@ -19,7 +19,7 @@ class CaptureQueueWorker extends QueueWorkerBase {
    */
   public function processItem($data) {
     // Check all required keys are provided.
-    $required = ['utility', 'url', 'run_uuid', 'run_entity'];
+    $required = ['utility', 'url', 'run_uuid', 'run_entity', 'user_agent'];
     foreach ($required as $key) {
       if (empty($data[$key])) {
         throw new \Exception("$key is required");

--- a/src/Validator/RobotsValidator.php
+++ b/src/Validator/RobotsValidator.php
@@ -36,7 +36,7 @@ class RobotsValidator {
   /**
    * Determines if a URL is crawlable based on robots.txt file.
    */
-  public function isCrawlable($url) {
+  public function isCrawlable($url, $user_agent = 'WPA') {
     static $robots = [];
 
     // Use default client if not previously set.
@@ -77,10 +77,7 @@ class RobotsValidator {
 
     // Apply robots.txt to URL.
     $parser = new \RobotsTxtParser($robots[$robots_file]);
-    // TODO: Move user agent from screenshot capture utility to config entity.
-    // In the mean time we just hardcode it here:
-    // @see https://www.drupal.org/node/2913374
-    return $parser->isAllowed($url, 'WPA');
+    return $parser->isAllowed($url, $user_agent);
   }
 
   /**

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -89,6 +89,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
         'timeout' => 500,
         'use_cron' => 1,
         'use_robots' => 0,
+        'user_agent' => 'MonkeyBot',
         'cron_schedule' => '0 9 1 1 *',
         'url_type' => 'url',
         'urls' => 'http://localhost',
@@ -102,6 +103,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('timeout', '500');
     $this->assertFieldByName('url_type', 'url');
     $this->assertFieldByName('urls', 'http://localhost');
+    $this->assertFieldByName('user_agent', 'MonkeyBot');
 
     // Add a screenshot capture utility.
     $this->drupalPostForm(
@@ -117,7 +119,6 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('data[clip_width]', '1280');
     $this->assertFieldByName('data[image_type]', 'png');
     $this->assertFieldByName('data[background_color]', '#ffffff');
-    $this->assertFieldByName('data[user_agent]', 'WPA');
 
     // Alter a few values and then submit.
     $this->drupalPostForm(
@@ -137,14 +138,12 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('data[clip_width]', '1280');
     $this->assertFieldByName('data[image_type]', 'jpg');
     $this->assertFieldByName('data[background_color]', '#ffffff');
-    $this->assertFieldByName('data[user_agent]', 'WPA');
 
-    // Attempt to change user agent and image type.
+    // Attempt to image type.
     $this->drupalPostForm(
       NULL,
       [
         'data[image_type]' => 'png',
-        'data[user_agent]' => 'Testbot 5000',
       ],
       t('Update capture utility')
     );
@@ -157,7 +156,6 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('data[clip_width]', '1280');
     $this->assertFieldByName('data[image_type]', 'png');
     $this->assertFieldByName('data[background_color]', '#ffffff');
-    $this->assertFieldByName('data[user_agent]', 'Testbot 5000');
 
     // Confirm entity list shows next scheduled time.
     $this->drupalGet('admin/config/system/web-page-archive');
@@ -172,6 +170,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
         'timeout' => 250,
         'use_cron' => 0,
         'use_robots' => 0,
+        'user_agent' => 'Secret Agent Man',
         'url_type' => 'url',
         'urls' => implode(PHP_EOL, [
           'http://localhost:1234/some-page',
@@ -185,6 +184,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     // Verify previous values are retained.
     $this->assertFieldByName('timeout', '250');
     $this->assertFieldByName('url_type', 'url');
+    $this->assertFieldByName('user_agent', 'Secret Agent Man');
     $this->assertFieldByName('urls', implode(PHP_EOL, [
       'http://localhost:1234/some-page',
       'http://localhost:1234/some-other-page',
@@ -214,6 +214,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
       'use_cron' => 0,
       'use_robots' => 0,
       'url_type' => 'sitemap',
+      'user_agent' => 'testbot',
       'urls' => 'http://localhost/sitemap.xml',
       'capture_utilities' => [
         '12345678-9999-0000-5555-000000000000' => [
@@ -224,7 +225,6 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
             'width' => 1280,
             'clip_width' => 1280,
             'background_color' => '#cc0000',
-            'user_agent' => 'testbot',
             'image_type' => 'png',
           ],
         ],
@@ -357,6 +357,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
       'use_robots' => 0,
       'url_type' => 'sitemap',
       'urls' => 'http://localhost/sitemap.xml',
+      'user_agent' => 'testbot',
       'capture_utilities' => [
         '12345678-9999-0000-5555-000000000000' => [
           'uuid' => '12345678-9999-0000-5555-000000000000',
@@ -366,7 +367,6 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
             'width' => 1280,
             'clip_width' => 1280,
             'background_color' => '#cc0000',
-            'user_agent' => 'testbot',
             'image_type' => 'png',
           ],
         ],
@@ -438,6 +438,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
         'timeout' => 500,
         'use_cron' => 1,
         'use_robots' => 1,
+        'user_agent' => 'WPA',
         'cron_schedule' => '* * * * *',
         'url_type' => 'url',
         'urls' => implode(PHP_EOL, $urls),

--- a/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
+++ b/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
@@ -70,6 +70,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
       'url' => 'http://www.whatever.com',
       'run_uuid' => '12345678-1234-1234-1234-123456789000',
       'run_entity' => $this->mockWebPageArchiveRun,
+      'user_agent' => 'WPA',
     ];
     $response = $this->queue->processItem($data);
     $this->assertSame('uri', $response->getType());
@@ -87,6 +88,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
       'url' => 'http://www.whatever.com',
       'run_uuid' => '12345678-1234-1234-1234-123456789000',
       'run_entity' => $this->mockWebPageArchiveRun,
+      'user_agent' => 'WPA',
     ];
     $response = $this->queue->processItem($data);
   }
@@ -102,6 +104,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
       'utility' => $this->mockHtmlCaptureUtility,
       'run_uuid' => '12345678-1234-1234-1234-123456789000',
       'run_entity' => $this->mockWebPageArchiveRun,
+      'user_agent' => 'WPA',
     ];
     $response = $this->queue->processItem($data);
   }
@@ -117,6 +120,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
       'utility' => $this->mockHtmlCaptureUtility,
       'url' => 'http://www.whatever.com',
       'run_entity' => $this->mockWebPageArchiveRun,
+      'user_agent' => 'WPA',
     ];
     $response = $this->queue->processItem($data);
   }
@@ -132,6 +136,23 @@ class CaptureQueueWorkerTest extends UnitTestCase {
       'utility' => $this->mockHtmlCaptureUtility,
       'url' => 'http://www.whatever.com',
       'run_uuid' => '12345678-1234-1234-1234-123456789000',
+      'user_agent' => 'WPA',
+    ];
+    $response = $this->queue->processItem($data);
+  }
+
+  /**
+   * Tests missing user_agent writes message.
+   *
+   * @expectedException Exception
+   * @expectedExceptionMessage user_agent is required
+   */
+  public function testMissingUserAgentWritesMessage() {
+    $data = [
+      'utility' => $this->mockHtmlCaptureUtility,
+      'url' => 'http://www.whatever.com',
+      'run_uuid' => '12345678-1234-1234-1234-123456789000',
+      'run_entity' => $this->mockWebPageArchiveRun,
     ];
     $response = $this->queue->processItem($data);
   }
@@ -155,6 +176,7 @@ class CaptureQueueWorkerTest extends UnitTestCase {
       'url' => 'http://www.whatever.com',
       'run_uuid' => '12345678-1234-1234-1234-123456789000',
       'run_entity' => $this->mockWebPageArchiveRun,
+      'user_agent' => 'WPA',
     ];
     $response = $this->queue->processItem($data);
   }

--- a/tests/src/Unit/Validator/RobotsValidatorTest.php
+++ b/tests/src/Unit/Validator/RobotsValidatorTest.php
@@ -47,56 +47,56 @@ class RobotsValidatorTest extends UnitTestCase {
    * Tests good URL is crawlable.
    */
   public function testsGoodUrlIsCrawlable() {
-    $this->assertTrue(static::$robotsValidator->isCrawlable('http://www.goodsite.com/'));
+    $this->assertTrue(static::$robotsValidator->isCrawlable('http://www.goodsite.com/', 'WPA'));
   }
 
   /**
    * Tests bad URL is not crawlable.
    */
   public function testsBadUrlIsNotCrawlable() {
-    $this->assertFalse(static::$robotsValidator->isCrawlable('http://www.goodsite.com/profiles/joe-smith'));
+    $this->assertFalse(static::$robotsValidator->isCrawlable('http://www.goodsite.com/profiles/joe-smith', 'WPA'));
   }
 
   /**
    * Tests URL is crawlable in empty robots.txt file.
    */
   public function testsEmptyRobotsFileAllowsCrawling() {
-    $this->assertTrue(static::$robotsValidator->isCrawlable('http://www.emptysite.com/profiles/joe-smith'));
+    $this->assertTrue(static::$robotsValidator->isCrawlable('http://www.emptysite.com/profiles/joe-smith', 'WPA'));
   }
 
   /**
    * Tests blocked user agent failed.
    */
   public function testsBlockedUserAgentDisallowsCrawling() {
-    $this->assertFalse(static::$robotsValidator->isCrawlable('https://www.blockedsite.com/about-us'));
+    $this->assertFalse(static::$robotsValidator->isCrawlable('https://www.blockedsite.com/about-us', 'WPA'));
   }
 
   /**
    * Tests unparseable file allows crawling.
    */
   public function testsUrlWithInvalidRobotsFileAllowsCrawling() {
-    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.somesite.com/invalid.file.txt'));
+    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.somesite.com/invalid.file.txt', 'WPA'));
   }
 
   /**
    * Tests unparseable file allows crawling.
    */
   public function testsUnparseableFileAllowsCrawling() {
-    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.somesite.com/invalid.file.png'));
+    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.someothersite.com/invalid.file.png', 'WPA'));
   }
 
   /**
    * Tests 4xx client error allows crawling.
    */
   public function testsClientErrorAllowsCrawling() {
-    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.somesite.com/access-denied-page'));
+    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.yetanothersite.com/access-denied-page', 'WPA'));
   }
 
   /**
    * Tests connection failure allows crawling.
    */
   public function testsRequestErrorAllowsCrawling() {
-    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.youcantconnecttome.com/peanut-butter'));
+    $this->assertTrue(static::$robotsValidator->isCrawlable('https://www.youcantconnecttome.com/peanut-butter', 'WPA'));
   }
 
 }

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -152,3 +152,37 @@ function web_page_archive_update_8004() {
     $wpa_config->save();
   }
 }
+
+/**
+ * Relocates user agent in all config entities.
+ */
+function web_page_archive_update_8005() {
+  $config_factory = \Drupal::service('config.factory');
+  $config_prefix = 'web_page_archive.web_page_archive';
+  $keys = $config_factory->listAll($config_prefix);
+
+  foreach ($keys as $key) {
+    $wpa_config = $config_factory->getEditable($key);
+    $utilities = $wpa_config->get('capture_utilities');
+    $user_agent = 'WPA';
+    $changed = FALSE;
+
+    // Search for screenshot capture utilities, grab and remove the user agent.
+    foreach ($utilities as $key => $utility) {
+      if ($utilities[$key]['id'] == 'wpa_screenshot_capture') {
+        if (isset($utilities[$key]['data']['user_agent'])) {
+          $changed = TRUE;
+          $user_agent = $utilities[$key]['data']['user_agent'];
+          unset($utilities[$key]['data']['user_agent']);
+        }
+      }
+    }
+
+    // Update user agent and capture utilities.
+    $wpa_config->set('user_agent', $user_agent);
+    if ($changed) {
+      $wpa_config->set('capture_utilities', $utilities);
+    }
+    $wpa_config->save();
+  }
+}


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2913374

This PR moves the user agent from the screenshot capture utility into the base config entity as it may be necessary for other capture types. 
