### PR TITLE
Issue #2906393: Delete folders on deletion of configuration entity

### DIFF
--- a/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -33,18 +33,14 @@ class HtmlCaptureUtility extends ConfigurableCaptureUtilityBase {
       throw new \Exception('Capture URL is required');
     }
 
-    $file_path = file_default_scheme() . "://";
-    $save_dir = "{$file_path}web-page-archive/html/{$data['web_page_archive']->id()}/{$data['run_uuid']}";
+    // Determine file locations.
+    $entity_id = $data['run_entity']->getConfigEntity()->id();
     $file_name = preg_replace('/[^a-z0-9]+/', '-', strtolower($data['url'])) . '.html';
-    $file_location = "{$save_dir}/{$file_name}";
+    $file_path = $this->storagePath($entity_id, $data['run_uuid']) . '/' . $file_name;
 
-    if (!file_prepare_directory($save_dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS)) {
-      throw new \Exception("Could not write to $save_dir");
-    }
-
-    \Drupal::httpClient()->request('GET', $data['url'], ['sink' => $file_location]);
-
-    $this->response = new HtmlCaptureResponse($file_location, $data['url']);
+    // Save html and set our response.
+    \Drupal::httpClient()->request('GET', $data['url'], ['sink' => $file_path]);
+    $this->response = new HtmlCaptureResponse($file_path, $data['url']);
 
     return $this;
   }

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -49,12 +49,11 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
     }
 
     // Determine file locations.
+    $entity_id = $data['run_entity']->getConfigEntity()->id();
     $file_name = preg_replace('/[^a-z0-9]+/', '-', strtolower($data['url']));
-    $scheme = file_default_scheme();
-    $folder_path = \Drupal::service('file_system')->realpath("{$scheme}://");
-    $file_location = "web-page-archive/screenshots/{$data['web_page_archive']->id()}/{$data['run_uuid']}/{$file_name}.{$this->configuration['image_type']}";
-    $real_file_path = "$folder_path/$file_location";
-    $file_path = "{$scheme}://{$file_location}";
+    $file_name .= ".{$this->configuration['image_type']}";
+    $file_path = $this->storagePath($entity_id, $data['run_uuid']) . '/' . $file_name;
+    $real_file_path = \Drupal::service('file_system')->realpath($file_path);
 
     // Save screenshot and set our response.
     $screenCapture->save($real_file_path);

--- a/src/Controller/CleanupController.php
+++ b/src/Controller/CleanupController.php
@@ -29,6 +29,7 @@ class CleanupController extends ControllerBase {
       foreach ($vids as $vid) {
         $utility->cleanupRevision($vid);
       }
+      $utility->cleanupEntity($web_page_archive->id());
     }
   }
 
@@ -38,6 +39,14 @@ class CleanupController extends ControllerBase {
   public static function queueFileDelete($file) {
     $queue = \Drupal::service('queue')->get('web_page_archive_cleanup');
     $queue->createItem(['type' => 'file', 'path' => $file]);
+  }
+
+  /**
+   * Queues a directory for deletion.
+   */
+  public static function queueDirectoryDelete($path) {
+    $queue = \Drupal::service('queue')->get('web_page_archive_cleanup');
+    $queue->createItem(['type' => 'directory', 'path' => $path]);
   }
 
   /**

--- a/src/Entity/WebPageArchiveRun.php
+++ b/src/Entity/WebPageArchiveRun.php
@@ -247,6 +247,7 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
       }
       $capture = [
         'uuid' => $uuid,
+        'run_uuid' => $data['run_uuid'],
         'timestamp' => \Drupal::service('datetime.time')->getCurrentTime(),
         'status' => 'complete',
         'capture_url' => $data['url'],

--- a/src/Plugin/CaptureUtilityInterface.php
+++ b/src/Plugin/CaptureUtilityInterface.php
@@ -80,11 +80,27 @@ interface CaptureUtilityInterface extends PluginInspectionInterface, Configurabl
   public function setWeight($weight);
 
   /**
+   * Performs cleanup on a config entity for the capture utility.
+   *
+   * @param string $entity_id
+   *   Specific entity to cleanup.
+   */
+  public function cleanupEntity($entity_id);
+
+  /**
    * Performs cleanup on a run entity revision for the capture utility.
    *
    * @param int $revision_id
    *   Specific revision to cleanup.
    */
   public function cleanupRevision($revision_id);
+
+  /**
+   * Returns the storage path for the specified run uuid.
+   *
+   * @param string $run_uuid
+   *   Specific run uuid to setup path form.
+   */
+  public function storagePath($run_uuid);
 
 }

--- a/src/Plugin/QueueWorker/FileCleanupQueueWorker.php
+++ b/src/Plugin/QueueWorker/FileCleanupQueueWorker.php
@@ -19,13 +19,27 @@ class FileCleanupQueueWorker extends QueueWorkerBase {
    */
   public function processItem($data) {
     if (file_exists($data['path'])) {
-      if (\Drupal::service('file_system')->unlink($data['path'])) {
-        return TRUE;
-      }
-      else {
-        throw new \Exception(t('Could not delete @file', ['@file' => $file]));
+      $logger = \Drupal::logger('web_page_archive');
+      switch ($data['type']) {
+        case 'file':
+          if (\Drupal::service('file_system')->unlink($data['path'])) {
+            $logger->notice(t('Deleted file @file', ['@file' => $data['path']]));
+            return TRUE;
+          }
+          else {
+            throw new \Exception(t('Could not delete @file', ['@file' => $data['path']]));
+          }
+        case 'directory':
+          if (\file_unmanaged_delete_recursive($data['path'])) {
+            $logger->notice(t('Deleted directory: @dir', ['@dir' => $data['path']]));
+            return TRUE;
+          }
+          else {
+            throw new \Exception(t('Could not delete @dir', ['@dir' => $data['path']]));
+          }
       }
     }
+
     return FALSE;
   }
 

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -490,8 +490,11 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     // Simulate a cron run.
     web_page_archive_cron();
 
-    // Assert file no longer exists.
+    // Assert file and directory no longer exist, but that the containing
+    // directory still does exist (i.e. make sure we're only deleting our run).
     $this->assertFalse(file_exists($file_path));
+    $this->assertFalse(file_exists('public://web-page-archive/wpa_html_capture/localhost'));
+    $this->assertTrue(file_exists('public://web-page-archive/wpa_html_capture'));
 
   }
 


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2906393

This PR deletes storage folders on config entity deletion. Here's an explanation of what is going on: 
1. I added a little bit of standardization for file paths across capture utilities. This is facilitate with the new `storagePath()` method inside `CaptureUtilityBase`.
2. I added a `queueDirectoryDelete()` method to the `CleanupController`.
3. Call `queueDirectoryDelete()` inside of `CleanupController::cleanRunEntity()`
4. Added run uuid to the serialized capture data.
5. `UriCaptureResponse::cleanupRevision` now keeps track of run_uuids and then calls `queueDirectoryDelete()` on individual run folders.
6. Modified 'FileCleanupQueueWorker()` to distinguish between and handle both files and directories.
7. Updated the functional test to confirm proper directories get deleted (and also that the deletion is limited to the scope of that single entity).