### PR TITLE
Issue #2918011 by WidgetsBurritos: Importing config entity doesn't initialize run entity

### DIFF
--- a/src/Controller/WebPageArchiveController.php
+++ b/src/Controller/WebPageArchiveController.php
@@ -38,16 +38,6 @@ class WebPageArchiveController extends ControllerBase {
       throw new \Exception("View not found!");
     }
     $run_entity = $web_page_archive->getRunEntity();
-    if (!isset($run_entity)) {
-      // TODO: What to do here? This is actually something we can correct.
-      // If a run entity does not exist for a config entity, we could generate
-      // one and then try again. That said, that may be indicative of a larger
-      // problem at which point we're just masking the error instead of
-      // correcting it. One case this may happen is if a user "Prepares for
-      // Uninstall" and then doesn't actually initiate an uninstall.
-      // Leaving this feedback here to resolve at a later time.
-      throw new \Exception("Missing run entity");
-    }
 
     $view->setDisplay('canonical_embed');
     $view->setArguments([$run_entity->id()]);

--- a/tests/src/Functional/WebPageArchiveConfigTest.php
+++ b/tests/src/Functional/WebPageArchiveConfigTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests web page archive configuration functionality.
+ *
+ * @group web_page_archive
+ */
+class WebPageArchiveConfigTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public $profile = 'minimal';
+
+  /**
+   * Authorized Admin User.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $authorizedAdminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'config',
+    'web_page_archive',
+    'wpa_html_capture',
+    'wpa_screenshot_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->authorizedAdminUser = $this->drupalCreateUser([
+      'administer web page archive',
+      'view web page archive results',
+      'administer site configuration',
+      'import configuration',
+    ]);
+  }
+
+  /**
+   * Functional test of importing web page archive entities with preset uuid.
+   */
+  public function testEntityImportWithUuid() {
+    // Import WPA entity.
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->authorizedAdminUser);
+    $this->drupalPostForm(
+      'admin/config/development/configuration/single/import',
+      [
+        'config_type' => 'web_page_archive',
+        'import' => file_get_contents(__DIR__ . '/fixtures/config-import-with-uuid.yml'),
+      ],
+      t('Import')
+    );
+    $this->drupalPostForm(NULL, [], t('Confirm'));
+    $this->drupalGet('admin/config/system/web-page-archive');
+    $assert->pageTextContains('Sample UUID Import Test');
+    $assert->pageTextContains('sample_uuid_import_test');
+    $this->clickLink('Edit');
+    $this->assertFieldByName('label', 'Sample UUID Import Test');
+    $this->assertFieldByName('cron_schedule', '30 * * * *');
+    $this->assertFieldByName('timeout', 1250);
+    $this->assertFieldByName('user_agent', 'NinjaBot');
+    $this->assertFieldByName('use_cron', 1);
+    $this->assertFieldByName('use_robots', 0);
+
+    // Check HTML capture utility.
+    $this->drupalGet('admin/config/system/web-page-archive/sample_uuid_import_test/utilities/7299908f-2cd3-4ff7-a902-69abab04478f');
+    $this->assertFieldByName('data[capture]', 1);
+
+    // Check Screenshot capture utility.
+    $this->drupalGet('admin/config/system/web-page-archive/sample_uuid_import_test/utilities/6ff62161-18dd-4450-8b08-b906b7392ff6');
+    $this->assertFieldByName('data[width]', 1500);
+    $this->assertFieldByName('data[background_color]', '#abc123');
+    $this->assertFieldByName('data[image_type]', 'jpg');
+    $this->assertFieldByName('data[delay]', 1000);
+  }
+
+  /**
+   * Functional test of importing web page archive entities with null uuid.
+   */
+  public function testEntityImportWithNullUuid() {
+    // Import WPA entity.
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->authorizedAdminUser);
+    $this->drupalPostForm(
+      'admin/config/development/configuration/single/import',
+      [
+        'config_type' => 'web_page_archive',
+        'import' => file_get_contents(__DIR__ . '/fixtures/config-import-with-null-uuid.yml'),
+      ],
+      t('Import')
+    );
+    $this->drupalPostForm(NULL, [], t('Confirm'));
+    $this->drupalGet('admin/config/system/web-page-archive');
+    $assert->pageTextContains('Sample Null UUID Import Test');
+    $assert->pageTextContains('sample_null_uuid_import_test');
+    $this->clickLink('Edit');
+    $this->assertFieldByName('label', 'Sample Null UUID Import Test');
+    $this->assertFieldByName('cron_schedule', '30 * * * *');
+    $this->assertFieldByName('timeout', 1250);
+    $this->assertFieldByName('user_agent', 'NinjaBot');
+    $this->assertFieldByName('use_cron', 1);
+    $this->assertFieldByName('use_robots', 0);
+
+    // Check HTML capture utility.
+    $this->drupalGet('admin/config/system/web-page-archive/sample_null_uuid_import_test/utilities/1299908f-2cd3-4ff7-a902-69abab04478f');
+    $this->assertFieldByName('data[capture]', 1);
+
+    // Check Screenshot capture utility.
+    $this->drupalGet('admin/config/system/web-page-archive/sample_null_uuid_import_test/utilities/1ff62161-18dd-4450-8b08-b906b7392ff6');
+    $this->assertFieldByName('data[width]', 1500);
+    $this->assertFieldByName('data[background_color]', '#abc123');
+    $this->assertFieldByName('data[image_type]', 'jpg');
+    $this->assertFieldByName('data[delay]', 1000);
+  }
+
+}

--- a/tests/src/Functional/fixtures/config-import-with-null-uuid.yml
+++ b/tests/src/Functional/fixtures/config-import-with-null-uuid.yml
@@ -1,0 +1,33 @@
+uuid: a3bf67e0-74ba-49bb-8e6c-9df9f824b111
+langcode: en
+status: true
+dependencies:
+  module:
+    - wpa_html_capture
+    - wpa_screenshot_capture
+id: sample_null_uuid_import_test
+label: 'Sample Null UUID Import Test'
+timeout: 1250
+url_type: url
+urls: 'https://www.drupal.org'
+use_robots: false
+use_cron: true
+user_agent: NinjaBot
+cron_schedule: '30 * * * *'
+capture_utilities:
+  1299908f-2cd3-4ff7-a902-69abab04478f:
+    uuid: 1299908f-2cd3-4ff7-a902-69abab04478f
+    id: wpa_html_capture
+    weight: 1
+    data:
+      capture: true
+  1ff62161-18dd-4450-8b08-b906b7392ff6:
+    uuid: 1ff62161-18dd-4450-8b08-b906b7392ff6
+    id: wpa_screenshot_capture
+    weight: 2
+    data:
+      width: 1500
+      background_color: '#abc123'
+      image_type: jpg
+      delay: 1000
+run_entity: null

--- a/tests/src/Functional/fixtures/config-import-with-uuid.yml
+++ b/tests/src/Functional/fixtures/config-import-with-uuid.yml
@@ -1,0 +1,33 @@
+uuid: a3bf67e0-74ba-49bb-8e6c-9df9f824b110
+langcode: en
+status: true
+dependencies:
+  module:
+    - wpa_html_capture
+    - wpa_screenshot_capture
+id: sample_uuid_import_test
+label: 'Sample UUID Import Test'
+timeout: 1250
+url_type: url
+urls: 'https://www.drupal.org'
+use_robots: false
+use_cron: true
+user_agent: NinjaBot
+cron_schedule: '30 * * * *'
+capture_utilities:
+  7299908f-2cd3-4ff7-a902-69abab04478f:
+    uuid: 7299908f-2cd3-4ff7-a902-69abab04478f
+    id: wpa_html_capture
+    weight: 1
+    data:
+      capture: true
+  6ff62161-18dd-4450-8b08-b906b7392ff6:
+    uuid: 6ff62161-18dd-4450-8b08-b906b7392ff6
+    id: wpa_screenshot_capture
+    weight: 2
+    data:
+      width: 1500
+      background_color: '#abc123'
+      image_type: jpg
+      delay: 1000
+run_entity: 1915f871-7e08-4d53-9139-dc86b0d8e5a0


### PR DESCRIPTION
Drupal.org issue: https://www.drupal.org/node/2918011

This PR fixes a bug where you can't import config entities using Drupal's configuration management system because the respective run entity doesn't get created properly. 

This PR does a couple of things: 
1.) I shift the check for needing to initializing the run entity from the entity `save()` to `getRunEntity()` method.  This means no matter where we try to retrieve the run entity, it will always validate the run entity. 
2.) I define "needing" a run entity as either missing a UUID or having a UUID that references an invalid run entity. This can happen, for instance, on config import where a run entity is specified but no such entity actually exists in the system. 
3.) I wrote functional tests to confirm configuration importing works properly.  You can compare this PR with #65 which is just the tests, which produces a failure. 