### PR TITLE
Issue #2908430 by WidgetsBurritos: Global Configuration Settings

### DIFF
--- a/config/install/web_page_archive.settings.yml
+++ b/config/install/web_page_archive.settings.yml
@@ -1,0 +1,12 @@
+cron:
+  capture_max: 100
+  file_cleanup: 50
+defaults:
+  cron_schedule: '@weekly'
+  label: ''
+  timeout: 500
+  url_type: url
+  urls: ''
+  use_cron: true
+  use_robots: true
+  user_agent: WPA

--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -1,3 +1,49 @@
+web_page_archive.settings:
+  type: config_object
+  label: 'Web page archive settings'
+  mapping:
+    cron:
+      type: mapping
+      mapping:
+        capture_max:
+          type: integer
+          label: 'Capture Max'
+        file_cleanup:
+          type: integer
+          label: 'File Cleanup'
+    defaults:
+      type: mapping
+      mapping:
+        id:
+          type: string
+          label: 'ID'
+        label:
+          type: label
+          label: 'Label'
+        uuid:
+          type: string
+        url_type:
+          type: string
+          label: 'URL Type'
+        urls:
+          type: string
+          label: 'URLs'
+        user_agent:
+          type: string
+          label: 'User Agent'
+        use_robots:
+          type: boolean
+          label: 'Honor robots.txt restrictions'
+        use_cron:
+          type: boolean
+          label: 'Use Cron?'
+        cron_schedule:
+          type: string
+          label: 'Cron Schedule'
+        timeout:
+          type: integer
+          label: 'Timeout (ms)'
+
 web_page_archive.web_page_archive.*:
   type: config_entity
   label: 'Web Page Archive config'

--- a/modules/wpa_html_capture/config/install/web_page_archive.wpa_html_capture.settings.yml
+++ b/modules/wpa_html_capture/config/install/web_page_archive.wpa_html_capture.settings.yml
@@ -1,0 +1,2 @@
+defaults:
+  capture: true

--- a/modules/wpa_html_capture/config/schema/wpa_html_capture.schema.yml
+++ b/modules/wpa_html_capture/config/schema/wpa_html_capture.schema.yml
@@ -5,3 +5,14 @@ web_page_archive.capture_utility.wpa_html_capture:
     capture:
       type: boolean
       label: 'Capture?'
+
+web_page_archive.wpa_html_capture.settings:
+  type: config_object
+  label: 'HTML Capture Utility settings'
+  mapping:
+    defaults:
+      type: mapping
+      mapping:
+        capture:
+          type: boolean
+          label: 'Capture?'

--- a/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureUtility/HtmlCaptureUtility.php
@@ -56,8 +56,9 @@ class HtmlCaptureUtility extends ConfigurableCaptureUtilityBase {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
+    $config = \Drupal::configFactory()->get('web_page_archive.wpa_html_capture.settings');
     return [
-      'capture' => TRUE,
+      'capture' => $config->get('defaults.capture'),
     ];
   }
 
@@ -71,6 +72,7 @@ class HtmlCaptureUtility extends ConfigurableCaptureUtilityBase {
       '#description' => $this->t('If checked, this archive will download and compare html.'),
       '#default_value' => $this->configuration['capture'],
     ];
+
     return $form;
   }
 

--- a/modules/wpa_html_capture/wpa_html_capture.install
+++ b/modules/wpa_html_capture/wpa_html_capture.install
@@ -5,6 +5,7 @@
  * Install commands for wpa_html_capture.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\wpa_html_capture\Plugin\CaptureResponse\HtmlCaptureResponse;
 
 /**
@@ -86,4 +87,14 @@ function wpa_html_capture_update_8001(&$sandbox = NULL) {
     \drupal_set_message($message, 'status');
   }
 
+}
+
+/**
+ * Installs new settings configuration.
+ */
+function wpa_html_capture_update_8002() {
+  $path = drupal_get_path('module', 'wpa_html_capture') . '/config/install';
+  $source = new FileStorage($path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('web_page_archive.wpa_html_capture.settings', $source->read('web_page_archive.wpa_html_capture.settings'));
 }

--- a/modules/wpa_screenshot_capture/config/install/web_page_archive.wpa_screenshot_capture.settings.yml
+++ b/modules/wpa_screenshot_capture/config/install/web_page_archive.wpa_screenshot_capture.settings.yml
@@ -1,0 +1,6 @@
+defaults:
+  background_color: '#ffffff'
+  delay: 0
+  image_type: png
+  user_agent: WPA
+  width: 1280

--- a/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
+++ b/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
@@ -17,3 +17,26 @@ web_page_archive.capture_utility.wpa_screenshot_capture:
     delay:
       type: integer
       label: 'Delay'
+
+web_page_archive.wpa_screenshot_capture.settings:
+  type: config_object
+  label: 'Screenshot Capture Utility settings'
+  mapping:
+    defaults:
+      type: mapping
+      mapping:
+        width:
+          type: integer
+          label: 'Width'
+        background_color:
+          type: string
+          label: 'Background color'
+        user_agent:
+          type: string
+          label: 'User agent'
+        image_type:
+          type: string
+          label: 'Image type'
+        delay:
+          type: integer
+          label: 'Delay'

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -97,15 +97,27 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form['intro'] = [
-      '#markup' => $this->t('Some instructions go here.'),
+  public function defaultConfiguration() {
+    $config = \Drupal::configFactory()->get('web_page_archive.wpa_screenshot_capture.settings');
+    return [
+      'width' => $config->get('defaults.width'),
+      'delay' => $config->get('defaults.delay'),
+      'background_color' => $config->get('defaults.background_color'),
+      'image_type' => $config->get('defaults.image_type'),
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $config = \Drupal::configFactory()->get('web_page_archive.wpa_screenshot_capture.settings');
+
     $form['width'] = [
       '#type' => 'number',
       '#title' => $this->t('Capture width (in pixels)'),
       '#description' => $this->t('Specify the width you would like to capture.'),
-      '#default_value' => isset($this->configuration['width']) ? $this->configuration['width'] : 1280,
+      '#default_value' => $this->configuration['width'],
       '#required' => TRUE,
     ];
     $image_types = Types::available();
@@ -115,20 +127,20 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       '#title' => $this->t('Image type'),
       '#options' => $image_types,
       '#empty_option' => $this->t('Select an image type'),
-      '#default_value' => isset($this->configuration['image_type']) ? $this->configuration['image_type'] : 'png',
+      '#default_value' => $this->configuration['image_type'],
       '#required' => TRUE,
     ];
     $form['background_color'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Browser background color'),
       '#description' => $this->t('Specify the browser background color in hexidecimal format. e.g. "#ffffff"'),
-      '#default_value' => isset($this->configuration['background_color']) ? $this->configuration['background_color'] : '#ffffff',
+      '#default_value' => $this->configuration['background_color'],
     ];
     $form['delay'] = [
       '#type' => 'number',
       '#title' => $this->t('Delay (ms)'),
       '#description' => $this->t('How long to delay before capturing a screenshot. This is helpful if you need to wait for javascript or resources to load.'),
-      '#default_value' => isset($this->configuration['delay']) ? $this->configuration['delay'] : 0,
+      '#default_value' => $this->configuration['delay'],
       '#required' => TRUE,
     ];
 

--- a/modules/wpa_screenshot_capture/wpa_screenshot_capture.install
+++ b/modules/wpa_screenshot_capture/wpa_screenshot_capture.install
@@ -5,6 +5,8 @@
  * Install commands for wpa_screenshot_capture.
  */
 
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Removes clip_width and adds delay to config entities.
  */
@@ -34,4 +36,14 @@ function wpa_screenshot_capture_update_8001() {
       $wpa_config->save();
     }
   }
+}
+
+/**
+ * Installs new settings configuration.
+ */
+function wpa_screenshot_capture_update_8002() {
+  $path = drupal_get_path('module', 'wpa_screenshot_capture') . '/config/install';
+  $source = new FileStorage($path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('web_page_archive.wpa_screenshot_capture.settings', $source->read('web_page_archive.wpa_screenshot_capture.settings'));
 }

--- a/modules/wpa_skeleton_capture/config/install/web_page_archive.wpa_skeleton_capture.settings.yml
+++ b/modules/wpa_skeleton_capture/config/install/web_page_archive.wpa_skeleton_capture.settings.yml
@@ -1,0 +1,2 @@
+defaults:
+  width: 1280

--- a/modules/wpa_skeleton_capture/config/schema/web_page_archive_example.schema.yml
+++ b/modules/wpa_skeleton_capture/config/schema/web_page_archive_example.schema.yml
@@ -5,3 +5,15 @@ web_page_archive.capture_utility.wpa_skeleton_capture:
     capture:
       type: int
       label: 'Width'
+
+
+web_page_archive.wpa_skeleton_capture.settings:
+  type: config_object
+  label: 'Skeleton Capture Utility settings'
+  mapping:
+    defaults:
+      type: mapping
+      mapping:
+        width:
+          type: integer
+          label: 'Width'

--- a/modules/wpa_skeleton_capture/src/Plugin/CaptureUtility/SkeletonCaptureUtility.php
+++ b/modules/wpa_skeleton_capture/src/Plugin/CaptureUtility/SkeletonCaptureUtility.php
@@ -54,8 +54,9 @@ class SkeletonCaptureUtility extends ConfigurableCaptureUtilityBase {
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
+    $config = \Drupal::configFactory()->get('web_page_archive.wpa_skeleton_capture.settings');
     return [
-      'width' => 1280,
+      'width' => $config->get('defaults.width'),
     ];
   }
 
@@ -69,7 +70,7 @@ class SkeletonCaptureUtility extends ConfigurableCaptureUtilityBase {
       '#type' => 'number',
       '#title' => $this->t('Width'),
       '#description' => $this->t('Capture width.'),
-      '#default_value' => isset($this->configuration['width']) ? $this->configuration['width'] : 1280,
+      '#default_value' => $this->configuration['width'],
     ];
     return $form;
   }

--- a/modules/wpa_skeleton_capture/wpa_skeleton_capture.install
+++ b/modules/wpa_skeleton_capture/wpa_skeleton_capture.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Install commands for wpa_html_capture.
+ */
+
+use Drupal\Core\Config\FileStorage;
+
+/**
+ * Installs new settings configuration.
+ */
+function wpa_skeleton_capture_update_8001() {
+  $path = drupal_get_path('module', 'wpa_skeleton_capture') . '/config/install';
+  $source = new FileStorage($path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('web_page_archive.wpa_skeleton_capture.settings', $source->read('web_page_archive.wpa_skeleton_capture.settings'));
+}

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Drupal\web_page_archive\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\SubformState;
+use Drupal\web_page_archive\Controller\WebPageArchiveController;
+use Drupal\web_page_archive\Plugin\CaptureUtilityManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Configure web page archive settings.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * Constructs a base class for web page archive add and edit forms.
+   *
+   * @param \Drupal\web_page_archive\Plugin\CaptureUtilityManager $capture_utility_manager
+   *   The capture utility manager service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   */
+  public function __construct(CaptureUtilityManager $capture_utility_manager, ConfigFactoryInterface $config_factory) {
+    $this->captureUtilityManager = $capture_utility_manager;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.capture_utility'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'web_page_archive_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'web_page_archive.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // If we're missing dependencies, we shouldn't have any form fields.
+    if (!WebPageArchiveController::checkDependencies()) {
+      return [];
+    }
+
+    // Attach form fields.
+    $this->buildFormCronSettings($form, $form_state);
+    $this->buildFormDefaults($form, $form_state);
+    $this->buildFormCaptureUtilityDefaults($form, $form_state);
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->submitFormSettings($form, $form_state);
+    $this->submitFormCaptureUtilitySettings($form, $form_state);
+    parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Attach module settings to the form array.
+   */
+  public function buildFormCronSettings(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('web_page_archive.settings');
+
+    $form['cron'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Cron Settings'),
+      '#tree' => TRUE,
+    ];
+
+    $form['cron']['capture_max'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Cron Capture Max'),
+      '#description' => $this->t('Maximum number of captures to process per cron run.'),
+      '#default_value' => $config->get('cron.capture_max'),
+    ];
+
+    $form['cron']['file_cleanup'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Cron File Cleanup'),
+      '#description' => $this->t('Maximum number of files marked for deletion to purge per cron run.'),
+      '#default_value' => $config->get('cron.file_cleanup'),
+    ];
+  }
+
+  /**
+   * Attach default config fields to the form array.
+   */
+  public function buildFormDefaults(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('web_page_archive.settings');
+
+    $form['defaults'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Default Entity Settings'),
+      '#tree' => TRUE,
+    ];
+
+    $form['defaults']['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Default Label'),
+      '#maxlength' => 255,
+      '#default_value' => $config->get('defaults.label'),
+      '#description' => $this->t("Label for the Web page archive entity."),
+    ];
+
+    // TODO: Convert to checkbox after checkbox can work with form states.
+    // @see https://www.drupal.org/node/994360
+    $form['defaults']['use_cron'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Run capture job automatically by default?'),
+      '#options' => [
+        1 => $this->t('Yes'),
+        0 => $this->t('No'),
+      ],
+      '#default_value' => $config->get('defaults.use_cron'),
+    ];
+
+    $use_cron_state = [['select[name="use_cron"]' => ['value' => '1']]];
+
+    $form['defaults']['cron_schedule'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t("Default crontab schedule (relative to PHP's default timezone)"),
+      '#description' => $this->t('Crontab format (see https://crontab.guru/)'),
+      '#default_value' => $config->get('defaults.cron_schedule'),
+      '#states' => [
+        'visible' => $use_cron_state,
+      ],
+    ];
+
+    $form['defaults']['timeout'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Default Timeout (ms)'),
+      '#description' => $this->t('Amount of time to wait between captures, in milliseconds.'),
+      '#default_value' => $config->get('defaults.timeout'),
+    ];
+
+    $form['defaults']['url_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Default Capture Type'),
+      '#options' => [
+        'url' => $this->t('URL'),
+        'sitemap' => $this->t('Sitemap URL'),
+      ],
+      '#default_value' => $config->get('defaults.url_type'),
+    ];
+
+    $form['defaults']['use_robots'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Honor robots.txt restrictions by default?'),
+      '#description' => $this->t('If checked, capture utility will respect robots.txt crawling rules.'),
+      '#options' => [
+        1 => $this->t('Yes'),
+        0 => $this->t('No'),
+      ],
+      '#default_value' => $config->get('defaults.use_robots'),
+      '#states' => [
+        'visible' => [
+          ['select[name="url_type"]' => ['value' => 'url']],
+          ['select[name="url_type"]' => ['value' => 'sitemap']],
+        ],
+      ],
+    ];
+
+    $form['defaults']['user_agent'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Default browser user agent'),
+      '#description' => $this->t('Specify the browser user agent. e.g. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"'),
+      '#default_value' => $config->get('defaults.user_agent'),
+    ];
+
+    $form['defaults']['urls'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Default URLs to Capture'),
+      '#description' => $this->t('A list of urls to capture.'),
+      '#default_value' => $config->get('defaults.urls'),
+      '#states' => [
+        'visible' => [
+          ['select[name="url_type"]' => ['value' => 'url']],
+          ['select[name="url_type"]' => ['value' => 'sitemap']],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Submit default entity settings.
+   */
+  public function submitFormSettings(array &$form, FormStateInterface $form_state) {
+    $settings = \Drupal::configFactory()->getEditable('web_page_archive.settings');
+    $groups = ['cron', 'defaults'];
+    foreach ($groups as $group) {
+      $defaults = $form_state->getValue($group);
+      foreach ($defaults as $field => $value) {
+        $settings->set("{$group}.{$field}", $value);
+      }
+    }
+    $settings->save();
+  }
+
+  /**
+   * Attach default capture utility config fields to the form array.
+   */
+  public function buildFormCaptureUtilityDefaults(array &$form, FormStateInterface $form_state) {
+    $plugin_definitions = $this->captureUtilityManager->getDefinitions();
+    foreach ($plugin_definitions as $plugin_definition) {
+      $config = $this->config("web_page_archive.{$plugin_definition['id']}.settings");
+      $form[$plugin_definition['id']] = [
+        '#type' => 'details',
+        '#title' => $this->t('@label Default Settings', ['@label' => $plugin_definition['label']]),
+        '#tree' => TRUE,
+      ];
+      $form[$plugin_definition['id']]['defaults'] = [];
+      $subform_state = SubformState::createForSubform($form[$plugin_definition['id']]['defaults'], $form, $form_state);
+      $capture_utility = $this->captureUtilityManager->createInstance($plugin_definition['id']);
+      $form[$plugin_definition['id']]['defaults'] = $capture_utility->buildConfigurationForm($form[$plugin_definition['id']]['defaults'], $subform_state);
+
+      $defaults = $config->get("defaults");
+      foreach ($defaults as $field => $value) {
+        $form[$plugin_definition['id']]['defaults'][$field]['#default_value'] = $value;
+        unset($form[$plugin_definition['id']]['defaults'][$field]['#required']);
+      }
+    }
+  }
+
+  /**
+   * Submit capture utilty default settings.
+   */
+  public function submitFormCaptureUtilitySettings(array &$form, FormStateInterface $form_state) {
+    $plugin_definitions = $this->captureUtilityManager->getDefinitions();
+    foreach ($plugin_definitions as $plugin_definition) {
+      $settings = $this->configFactory->getEditable("web_page_archive.{$plugin_definition['id']}.settings");
+      $defaults = $form_state->getValue($plugin_definition['id']);
+      foreach ($defaults['defaults'] as $field => $value) {
+        $settings->set("defaults.{$field}", $value);
+      }
+      $settings->save();
+    }
+  }
+
+}

--- a/src/Form/WebPageArchiveFormBase.php
+++ b/src/Form/WebPageArchiveFormBase.php
@@ -69,11 +69,13 @@ abstract class WebPageArchiveFormBase extends EntityForm {
       return [];
     }
 
+    $config = $this->config('web_page_archive.settings');
+
     $form['label'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Label'),
       '#maxlength' => 255,
-      '#default_value' => $this->entity->label(),
+      '#default_value' => !$this->entity->isNew() ? $this->entity->label() : $config->get('defaults.label'),
       '#description' => $this->t("Label for the Web page archive entity."),
       '#required' => TRUE,
     ];
@@ -96,7 +98,7 @@ abstract class WebPageArchiveFormBase extends EntityForm {
         1 => $this->t('Yes'),
         0 => $this->t('No'),
       ],
-      '#default_value' => !$this->entity->isNew() ? (int) $this->entity->getUseCron() : 1,
+      '#default_value' => !$this->entity->isNew() ? (int) $this->entity->getUseCron() : (int) $config->get('defaults.use_cron'),
     ];
 
     $use_cron_state = [['select[name="use_cron"]' => ['value' => '1']]];
@@ -105,7 +107,7 @@ abstract class WebPageArchiveFormBase extends EntityForm {
       '#type' => 'textfield',
       '#title' => $this->t("Crontab schedule (relative to PHP's default timezone)"),
       '#description' => $this->t('Crontab format (see https://crontab.guru/)'),
-      '#default_value' => !$this->entity->isNew() ? $this->entity->getCronSchedule() : '@weekly',
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getCronSchedule() : $config->get('defaults.cron_schedule'),
       '#states' => [
         'visible' => $use_cron_state,
       ],
@@ -127,7 +129,7 @@ abstract class WebPageArchiveFormBase extends EntityForm {
       '#type' => 'number',
       '#title' => $this->t('Timeout (ms)'),
       '#description' => $this->t('Amount of time to wait between captures, in milliseconds.'),
-      '#default_value' => !$this->entity->isNew() ? $this->entity->getTimeout() : 250,
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getTimeout() : $config->get('defaults.timeout'),
     ];
 
     $form['url_type'] = [
@@ -137,7 +139,7 @@ abstract class WebPageArchiveFormBase extends EntityForm {
         'url' => $this->t('URL'),
         'sitemap' => $this->t('Sitemap URL'),
       ],
-      '#default_value' => $this->entity->getUrlType(),
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getUrlType() : $config->get('defaults.url_type'),
     ];
 
     $form['use_robots'] = [
@@ -148,7 +150,7 @@ abstract class WebPageArchiveFormBase extends EntityForm {
         1 => $this->t('Yes'),
         0 => $this->t('No'),
       ],
-      '#default_value' => !$this->entity->isNew() ? (int) $this->entity->getUseRobots() : 1,
+      '#default_value' => !$this->entity->isNew() ? (int) $this->entity->getUseRobots() : (int) $config->get('defaults.use_robots'),
       '#states' => [
         'visible' => [
           ['select[name="url_type"]' => ['value' => 'url']],
@@ -161,14 +163,14 @@ abstract class WebPageArchiveFormBase extends EntityForm {
       '#type' => 'textfield',
       '#title' => $this->t('Browser user agent'),
       '#description' => $this->t('Specify the browser user agent. e.g. "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"'),
-      '#default_value' => !$this->entity->isNew() ? $this->entity->getUserAgent() : $this->t('WPA'),
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getUserAgent() : $config->get('defaults.user_agent'),
     ];
 
     $form['urls'] = [
       '#type' => 'textarea',
       '#title' => $this->t('URLs to Capture'),
       '#description' => $this->t('A list of urls to capture.'),
-      '#default_value' => $this->entity->getUrlsText(),
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getUrlsText() : $config->get('defaults.urls'),
       '#states' => [
         'visible' => [
           ['select[name="url_type"]' => ['value' => 'url']],

--- a/tests/src/Functional/WebPageArchiveSettingsTest.php
+++ b/tests/src/Functional/WebPageArchiveSettingsTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests web page archive configuration functionality.
+ *
+ * @group web_page_archive
+ */
+class WebPageArchiveSettingsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public $profile = 'minimal';
+
+  /**
+   * Authorized Admin User.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $authorizedAdminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'config',
+    'web_page_archive',
+    'wpa_html_capture',
+    'wpa_screenshot_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->authorizedAdminUser = $this->drupalCreateUser([
+      'administer web page archive',
+      'view web page archive results',
+    ]);
+  }
+
+  /**
+   * Functional test of default WPA settings.
+   */
+  public function testSettingsExistAndHaveDefaultValues() {
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->authorizedAdminUser);
+
+    // Ensure settings link is exposed in UI.
+    $this->drupalGet('admin/config/system/web-page-archive');
+    $this->clickLink('Settings');
+
+    // Confirm default entity settings exist and populate defaults.
+    $assert->pageTextContains('Default Entity Settings');
+    $this->assertFieldByName('cron[capture_max]', 100);
+    $this->assertFieldByName('cron[file_cleanup]', 50);
+    $this->assertFieldByName('defaults[label]', '');
+    $this->assertFieldByName('defaults[cron_schedule]', '@weekly');
+    $this->assertFieldByName('defaults[timeout]', 500);
+    $this->assertFieldByName('defaults[url_type]', 'url');
+    $this->assertFieldByName('defaults[user_agent]', 'WPA');
+    $this->assertFieldByName('defaults[use_cron]', 1);
+    $this->assertFieldByName('defaults[use_robots]', 1);
+
+    // Attempt to set defaults.
+    $this->drupalPostForm(
+      NULL,
+      [
+        'cron[capture_max]' => 500,
+        'cron[file_cleanup]' => 150,
+        'defaults[label]' => 'New default label',
+        'defaults[cron_schedule]' => '30 * * * *',
+        'defaults[timeout]' => 1500,
+        'defaults[url_type]' => 'sitemap',
+        'defaults[user_agent]' => 'NinjaBot',
+        'defaults[use_robots]' => 0,
+      ],
+      t('Save configuration')
+    );
+
+    // Confirm default entity settings updated.
+    $this->assertFieldByName('cron[capture_max]', 500);
+    $this->assertFieldByName('cron[file_cleanup]', 150);
+    $this->assertFieldByName('defaults[label]', 'New default label');
+    $this->assertFieldByName('defaults[cron_schedule]', '30 * * * *');
+    $this->assertFieldByName('defaults[timeout]', 1500);
+    $this->assertFieldByName('defaults[url_type]', 'sitemap');
+    $this->assertFieldByName('defaults[user_agent]', 'NinjaBot');
+    $this->assertFieldByName('defaults[use_robots]', 0);
+
+    // Ensure default values made it into the add form.
+    $this->drupalGet('admin/config/system/web-page-archive/add');
+    $this->assertFieldByName('label', 'New default label');
+    $this->assertFieldByName('cron_schedule', '30 * * * *');
+    $this->assertFieldByName('timeout', 1500);
+    $this->assertFieldByName('url_type', 'sitemap');
+    $this->assertFieldByName('user_agent', 'NinjaBot');
+    $this->assertFieldByName('use_robots', 0);
+  }
+
+  /**
+   * Functional test of default capture utility settings.
+   */
+  public function testCaptureUtilitySettingsExistAndHaveDefaultValues() {
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->authorizedAdminUser);
+
+    // Ensure settings link is exposed in UI.
+    $this->drupalGet('admin/config/system/web-page-archive');
+    $this->clickLink('Settings');
+
+    // Confirm HTML capture utility section exists and populates defaults.
+    $assert->pageTextContains('HTML capture utility Default Settings');
+    $this->assertFieldByName('wpa_html_capture[defaults][capture]', 1);
+
+    // Confirm screenshot capture utility section exists and populates defaults.
+    $assert->pageTextContains('Screenshot capture utility Default Settings');
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][background_color]', '#ffffff');
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][delay]', 0);
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][image_type]', 'png');
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][width]', 1280);
+
+    // Attempt to set defaults.
+    $this->drupalPostForm(
+      NULL,
+      [
+        'wpa_html_capture[defaults][capture]' => 0,
+        'wpa_screenshot_capture[defaults][background_color]' => '#abc123',
+        'wpa_screenshot_capture[defaults][delay]' => 150,
+        'wpa_screenshot_capture[defaults][image_type]' => 'jpg',
+        'wpa_screenshot_capture[defaults][width]' => 1400,
+      ],
+      t('Save configuration')
+    );
+
+    // Confirm HTML capture utility settings updated.
+    $this->assertFieldByName('wpa_html_capture[defaults][capture]', 0);
+
+    // Confirm screenshot capture utility settings updated.
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][background_color]', '#abc123');
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][delay]', 150);
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][image_type]', 'jpg');
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][width]', 1400);
+
+    // Create a dummy entity with no capture utilities.
+    $data = [
+      'label' => 'Programmatic Archive',
+      'id' => 'programmatic_archive',
+      'timeout' => 500,
+      'use_cron' => 0,
+      'use_robots' => 0,
+      'url_type' => 'sitemap',
+      'user_agent' => 'testbot',
+      'urls' => 'http://localhost/sitemap.xml',
+      'capture_utilities' => [],
+    ];
+    $wpa = \Drupal::entityTypeManager()
+      ->getStorage('web_page_archive')
+      ->create($data);
+    $wpa->save();
+
+    // Add a HTML capture utility to the config entity and test defaults.
+    $this->drupalGet('admin/config/system/web-page-archive/programmatic_archive/edit');
+    $this->drupalPostForm(NULL, ['new' => 'wpa_html_capture'], t('Add'));
+    $this->assertNoFieldChecked('data[capture]');
+
+    // Add a screenshot capture utilitiy to the config entity and test defaults.
+    $this->drupalGet('admin/config/system/web-page-archive/programmatic_archive/edit');
+    $this->drupalPostForm(NULL, ['new' => 'wpa_screenshot_capture'], t('Add'));
+    $this->assertFieldByName('data[background_color]', '#abc123');
+    $this->assertFieldByName('data[delay]', 150);
+    $this->assertFieldByName('data[image_type]', 'jpg');
+    $this->assertFieldByName('data[width]', 1400);
+
+  }
+
+}

--- a/tests/src/Unit/Cron/CronRunnerTest.php
+++ b/tests/src/Unit/Cron/CronRunnerTest.php
@@ -72,6 +72,29 @@ class CronRunnerTest extends UnitTestCase {
   }
 
   /**
+   * Helper function to get a config factory service.
+   */
+  private function getMockConfigFactory() {
+    $mock_config_factory = $this->getMockBuilder('\Drupal\Core\Config\ConfigFactory')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $mock_config = $this->getMockBuilder('\Drupal\Core\Config\ImmutableConfig')
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $mock_config->expects($this->any())
+      ->method('get')
+      ->will($this->returnValue(25));
+
+    $mock_config_factory->expects($this->any())
+      ->method('get')
+      ->will($this->returnValue($mock_config));
+
+    return $mock_config_factory;
+  }
+
+  /**
    * Helper function to get a cron runner based on default or supplied mocks.
    */
   private function getCronRunner(array $options = []) {
@@ -84,8 +107,11 @@ class CronRunnerTest extends UnitTestCase {
     if (empty($options['mock_state'])) {
       $options['mock_state'] = $this->getMockState();
     }
+    if (empty($options['mock_config_factory'])) {
+      $options['mock_config_factory'] = $this->getMockConfigFactory();
+    }
 
-    return new CronRunner($options['mock_lock'], $options['mock_state'], $options['mock_time']);
+    return new CronRunner($options['mock_lock'], $options['mock_state'], $options['mock_time'], $options['mock_config_factory']);
   }
 
   /**
@@ -180,6 +206,14 @@ class CronRunnerTest extends UnitTestCase {
     $mock_web_page_archive = $this->getMockWebPageArchive();
     $cron_runner = $this->getCronRunner();
     $this->assertFalse($cron_runner->run($mock_web_page_archive));
+  }
+
+  /**
+   * Tests capture max is pulled from configuration.
+   */
+  public function testCaptureMaxReturnsProperValue() {
+    $cron_runner = $this->getCronRunner();
+    $this->assertEquals(25, $cron_runner->getCaptureMax());
   }
 
 }

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -5,6 +5,7 @@
  * Install commands for web_page_archive.
  */
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
@@ -203,4 +204,14 @@ function web_page_archive_update_8006() {
     $query->condition('vid', $revision_id);
     $query->execute();
   }
+}
+
+/**
+ * Installs new settings configuration.
+ */
+function web_page_archive_update_8007() {
+  $path = drupal_get_path('module', 'web_page_archive') . '/config/install';
+  $source = new FileStorage($path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('web_page_archive.settings', $source->read('web_page_archive.settings'));
 }

--- a/web_page_archive.links.task.yml
+++ b/web_page_archive.links.task.yml
@@ -3,6 +3,12 @@ entity.web_page_archive.collection:
   route_name: entity.web_page_archive.collection
   base_route: entity.web_page_archive.collection
 
+web_page_archive_settings:
+  title: 'Settings'
+  base_route: entity.web_page_archive.collection
+  route_name: web_page_archive_settings
+  weight: -10
+
 entity.web_page_archive.collection.prepare_uninstall:
   title: 'Prepare uninstall'
   description: 'Remove fields and data created by web page archive module.'

--- a/web_page_archive.module
+++ b/web_page_archive.module
@@ -37,5 +37,7 @@ function web_page_archive_cron() {
   }
 
   // Cleanup files.
-  CleanupController::processCleanup(50);
+  $config = \Drupal::service('config.factory');
+  $file_cleanup = $config->get('web_page_archive.settings')->get('cron.file_cleanup');
+  CleanupController::processCleanup($file_cleanup);
 }

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -6,6 +6,14 @@ entity.web_page_archive.collection:
   requirements:
     _permission: 'view web page archive results'
 
+web_page_archive_settings:
+  path: 'admin/config/system/web-page-archive/settings'
+  defaults:
+    _form: '\Drupal\web_page_archive\Form\SettingsForm'
+    _title: 'Web Page Archive Settings'
+  requirements:
+    _permission: 'administer web page archive'
+
 entity.web_page_archive.add_form:
   path: 'admin/config/system/web-page-archive/add'
   defaults:

--- a/web_page_archive.services.yml
+++ b/web_page_archive.services.yml
@@ -20,6 +20,6 @@ services:
       - { name: validator }
   web_page_archive.cron.runner:
     class: Drupal\web_page_archive\Cron\CronRunner
-    arguments: ['@lock', '@state', '@datetime.time']
+    arguments: ['@lock', '@state', '@datetime.time', '@config.factory']
     tags:
       - { name: cron }


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2908430

This PR introduces global configuration settings page to manage default settings for config entities and capture utilities. The functionality mostly works. I still need to add in functional tests for this which is why it's still WIP, but opening the PR just to get an initial round of tests going. 