### PR TITLE
Issue #2931285 by WidgetsBurritos: Create Basic Diff Functionality

### DIFF
--- a/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -18,6 +18,13 @@ class HtmlCaptureResponse extends UriCaptureResponse {
   /**
    * {@inheritdoc}
    */
+  public static function getId() {
+    return 'wpa_html_capture_response';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function renderable(array $options = []) {
     return (isset($options['mode']) && $options['mode'] == 'full') ?
       $this->renderFull($options) : $this->renderPreview($options);

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
@@ -15,6 +15,13 @@ class ScreenshotCaptureResponse extends UriCaptureResponse {
   /**
    * {@inheritdoc}
    */
+  public static function getId() {
+    return 'wpa_screenshot_capture_response';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function renderable(array $options = []) {
     return (isset($options['mode']) && $options['mode'] == 'full') ?
       $this->renderFull($options) : $this->renderPreview($options);

--- a/src/Controller/RunComparisonController.php
+++ b/src/Controller/RunComparisonController.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace Drupal\web_page_archive\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Component\Utility\Tags;
+use Drupal\Component\Utility\Unicode;
+use Drupal\web_page_archive\Entity\RunComparisonInterface;
+use Drupal\web_page_archive\Entity\Sql\WebPageArchiveRunStorageInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines a route controller for comparing two run revisions.
+ */
+class RunComparisonController extends ControllerBase {
+
+  private $runStorage;
+
+  /**
+   * Constructs a base class for autocompletion.
+   *
+   * @param \Drupal\web_page_archive\Entity\Sql\WebPageArchiveRunStorageInterface $run_storage
+   *   Web page archive run storage.
+   */
+  public function __construct(WebPageArchiveRunStorageInterface $run_storage) {
+    $this->runStorage = $run_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')->getStorage('web_page_archive_run')
+    );
+  }
+
+  /**
+   * Generates a label for the specified revision.
+   */
+  public static function generateRevisionLabel($vid, $name, $timestamp) {
+    $timezone = \drupal_get_user_timezone();
+    $date = \Drupal::service('date.formatter')
+      ->format($timestamp, 'custom', 'Y-m-d H:i:s', $timezone);
+    return "{$name}: {$date} ($vid)";
+  }
+
+  /**
+   * Handler for autocomplete request.
+   */
+  public function handleRunAutocomplete(Request $request) {
+    $results = [];
+    $max_results = 15;
+    $revisions = $this->runStorage->fullRevisionList();
+
+    if ($input = $request->query->get('q')) {
+      $typed_string = Tags::explode($input);
+      $typed_string = Unicode::strtolower(array_pop($typed_string));
+      $count = 0;
+      foreach ($revisions as $revision) {
+        $label = static::generateRevisionLabel($revision->vid, $revision->name, $revision->revision_created);
+        if (stristr($label, $typed_string) !== FALSE) {
+          $results[] = ['label' => $label, 'value' => $revision->vid];
+          $count++;
+          if ($count > $max_results) {
+            break;
+          }
+        }
+      }
+    }
+
+    return new JsonResponse($results);
+  }
+
+  /**
+   * Generates a matrix of captured URLs for each run.
+   */
+  public static function generateRunMatrix($runs) {
+    $urls = [];
+    foreach ($runs as $run) {
+      foreach ($run->getCapturedArray() as $captured_row) {
+        if (empty($captured_row->getValue()['value'])) {
+          continue;
+        }
+
+        $row_results = unserialize($captured_row->getValue()['value']);
+        $response_type = $row_results['capture_response']->getId();
+        $capture_key = $row_results['capture_url'];
+        $run_id = $run->getRevisionId();
+        $delta = $row_results['delta'];
+        $urls[$response_type][$capture_key][$run_id][$delta] = $row_results;
+      }
+    }
+    return $urls;
+  }
+
+  /**
+   * Enqueues the run comparisons to be performed.
+   */
+  public static function enqueueRunComparisons(RunComparisonInterface $run_comparison) {
+    // Retrieve and reset our queue.
+    $queue = $run_comparison->getQueue();
+    $queue->deleteQueue();
+    $queue->createQueue();
+
+    // Ensure we have two valid runs to compare.
+    $run_entities = $run_comparison->getRunEntities();
+    if (count($run_entities) !== 2) {
+      throw new \Exception('Invalid comparison object');
+    }
+
+    // Determine if URLs are in both runs or just one and mark accordingly.
+    $matrix = static::generateRunMatrix($run_entities);
+    $left_id = $run_entities[0]->getRevisionId();
+    $right_id = $run_entities[1]->getRevisionId();
+    foreach ($matrix as $response_type => $capture_list) {
+      foreach ($capture_list as $url => $runs) {
+        $first_run = isset($runs[$left_id]) ? reset($runs[$left_id]) : reset($runs[$right_id]);
+        $compare_class = isset($first_run['capture_response']) ? get_class($first_run['capture_response']) : NULL;
+        $item = [
+          'compare_class' => $compare_class,
+          'left_id' => $left_id,
+          'right_id' => $right_id,
+          'run_comparison' => $run_comparison,
+          'runs' => $runs,
+          'url' => $url,
+        ];
+        $queue->createItem($item);
+      }
+    }
+  }
+
+  /**
+   * Marks a capture as complete.
+   */
+  public static function markCompareComplete($data) {
+    $store_data = [
+      'url' => $data['url'],
+      'delta1' => $data['delta1'],
+      'delta2' => $data['delta2'],
+      'has_left' => $data['has_left'],
+      'has_right' => $data['has_right'],
+      'langcode' => $data['run_comparison']->language()->getId(),
+      'run1' => $data['left_id'],
+      'run2' => $data['right_id'],
+      'results' => serialize($data),
+      'variance' => $data['variance'],
+    ];
+
+    \Drupal::entityTypeManager()->getStorage('wpa_run_comparison')
+      ->addResult($data['run_comparison'], $store_data);
+  }
+
+  /**
+   * Adds up to $items_to_process number of items from the queue to a batch.
+   *
+   * If $items_to_process < 0 attempt to add entire queue to batch.
+   */
+  public static function setBatch(RunComparisonInterface $run_comparison, $items_to_process = -1) {
+    $queue = $run_comparison->getQueue();
+    $queue_worker = \Drupal::service('plugin.manager.queue_worker')->createInstance('web_page_archive_compare');
+
+    // Create capture job batch.
+    $batch = [
+      'title' => \t('Process all compare queue jobs with batch'),
+      'operations' => [],
+      'finished' => 'Drupal\web_page_archive\Controller\RunComparisonController::batchFinished',
+    ];
+
+    // If negative, or if count is too high, set count to queue size.
+    if ($items_to_process < 0 || $items_to_process > $queue->numberOfItems()) {
+      $items_to_process = $queue->numberOfItems();
+    }
+
+    // Create batch operations.
+    for ($i = 0; $i < $items_to_process; $i++) {
+      $batch['operations'][] = ['Drupal\web_page_archive\Controller\RunComparisonController::batchProcess', [$run_comparison]];
+    }
+
+    // Adds the batch sets.
+    batch_set($batch);
+  }
+
+  /**
+   * Processes a batch request.
+   */
+  public static function batchProcess(RunComparisonInterface $run_comparison, &$context = NULL) {
+    $queue = $run_comparison->getQueue();
+    $queue_worker = \Drupal::service('plugin.manager.queue_worker')->createInstance('web_page_archive_compare');
+
+    if ($item = $queue->claimItem()) {
+      try {
+        $processed = $queue_worker->processItem($item->data);
+        if (!isset($processed)) {
+          throw new RequeueException(t('Still Running'));
+        }
+        $queue->deleteItem($item);
+        return TRUE;
+      }
+      catch (RequeueException $e) {
+        $queue->releaseItem($item);
+      }
+      catch (SuspendQueueException $e) {
+        $queue->releaseItem($item);
+        watchdog_exception($e);
+      }
+      catch (\Exception $e) {
+        // In case of any other kind of exception, log it and remove it from
+        // the queue to prevent queues from getting stuck.
+        $queue->deleteItem($item);
+        watchdog_exception('cron', $e);
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Batch finished callback.
+   */
+  public static function batchFinished($success, $results, $operations) {
+    if ($success) {
+      \drupal_set_message(\t("The comparison has been completed."));
+    }
+    else {
+      $error_operation = reset($operations);
+      $values = [
+        '@operation' => $error_operation[0],
+        '@args' => print_r($error_operation[0], TRUE),
+      ];
+      \drupal_set_message(\t('An error occurred while processing @operation with arguments : @args', $values));
+    }
+  }
+
+  /**
+   * Displays the run summary for the specified run comparison object.
+   */
+  public static function summary($wpa_run_comparison) {
+    return [
+      '#markup' => 'TODO: Add something here',
+    ];
+  }
+
+  /**
+   * Displays the summary title for the specified run comparison object.
+   */
+  public static function summaryTitle($wpa_run_comparison) {
+    return $wpa_run_comparison->label();
+  }
+
+}

--- a/src/Entity/RunComparison.php
+++ b/src/Entity/RunComparison.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Drupal\web_page_archive\Entity;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\RevisionableContentEntityBase;
+use Drupal\Core\Entity\EntityChangedTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Defines the run comparison entity.
+ *
+ * @ingroup web_page_archive
+ *
+ * @ContentEntityType(
+ *   id = "wpa_run_comparison",
+ *   label = @Translation("Web Page Archive Run Comparison"),
+ *   handlers = {
+ *     "storage" = "Drupal\web_page_archive\Entity\Sql\RunComparisonStorage",
+ *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "form" = {
+ *       "delete" = "Drupal\web_page_archive\Form\RunComparisonDeleteForm",
+ *     },
+ *   },
+ *   base_table = "wpa_run_comparison",
+ *   revision_table = "wpa_run_comparison_revision",
+ *   revision_data_table = "wpa_run_comparison_field_revision",
+ *   admin_permission = "administer web page archive",
+ *   fieldable = TRUE,
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "revision" = "vid",
+ *     "label" = "name",
+ *     "uuid" = "uuid",
+ *     "uid" = "user_id",
+ *     "langcode" = "langcode",
+ *     "status" = "status",
+ *   },
+ *   field_ui_base_route = "wpa_run_comparison.settings"
+ * )
+ */
+class RunComparison extends RevisionableContentEntityBase implements RunComparisonInterface {
+
+  use EntityChangedTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
+    parent::preCreate($storage_controller, $values);
+    $values += [
+      'user_id' => \Drupal::currentUser()->id(),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preSave(EntityStorageInterface $storage) {
+    parent::preSave($storage);
+
+    foreach (array_keys($this->getTranslationLanguages()) as $langcode) {
+      $translation = $this->getTranslation($langcode);
+
+      // If no owner has been set explicitly, make the anonymous user the owner.
+      if (!$translation->getOwner()) {
+        $translation->setOwnerId(0);
+      }
+    }
+
+    // If no revision author has been set explicitly, make the entity owner the
+    // revision author.
+    if (!$this->getRevisionUser()) {
+      $this->setRevisionUserId($this->getOwnerId());
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return $this->get('name')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setName($name) {
+    $this->set('name', $name);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCreatedTime() {
+    return $this->get('created')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setCreatedTime($timestamp) {
+    $this->set('created', $timestamp);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOwner() {
+    return $this->get('user_id')->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOwnerId() {
+    return $this->get('user_id')->target_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwnerId($uid) {
+    $this->set('user_id', $uid);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setOwner(UserInterface $account) {
+    $this->set('user_id', $account->id());
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRun1() {
+    return \Drupal::entityTypeManager()->getStorage('web_page_archive_run')->loadRevision($this->getRun1Id());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRun1Id() {
+    return (int) $this->get('run1')->getString();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRun2() {
+    return \Drupal::entityTypeManager()->getStorage('web_page_archive_run')->loadRevision($this->getRun2Id());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRun2Id() {
+    return (int) $this->get('run2')->getString();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRunEntities() {
+    return [$this->getRun1(), $this->getRun2()];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQueue() {
+    $queue_name = "web_page_archive_compare.{$this->uuid()}";
+    return \Drupal::service('queue')->get($queue_name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResults() {
+    return \Drupal::entityTypeManager()->getStorage('wpa_run_comparison')->getResults($this);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Authored by'))
+      ->setDescription(t('The user ID of author of the Web page archive run entity.'))
+      ->setRevisionable(TRUE)
+      ->setSetting('target_type', 'user')
+      ->setSetting('handler', 'default')
+      ->setTranslatable(TRUE)
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'author',
+        'weight' => 0,
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 5,
+        'settings' => [
+          'match_operator' => 'CONTAINS',
+          'size' => '60',
+          'autocomplete_type' => 'tags',
+          'placeholder' => '',
+        ],
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['name'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Name'))
+      ->setDescription(t('The name of the comparison.'))
+      // ->setRevisionable(TRUE)
+      ->setSettings([
+        'max_length' => 255,
+        'text_processing' => 0,
+      ])
+      ->setDefaultValue('')
+      ->setDisplayOptions('view', [
+        'label' => 'above',
+        'type' => 'string',
+        'weight' => -4,
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'string_textfield',
+        'weight' => -4,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+    $fields['status'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Run status'))
+      ->setDescription(t('A boolean indicating whether the run comparison is published.'))
+      ->setRevisionable(TRUE)
+      ->setDefaultValue(TRUE);
+
+    $fields['run1'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Run 1 ID'))
+      ->setDescription(t('The first run ID.'))
+      ->setRevisionable(FALSE);
+
+    $fields['run2'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Run 2 ID'))
+      ->setDescription(t('The second run ID.'))
+      ->setRevisionable(FALSE);
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Created'))
+      ->setDescription(t('The time that the entity was created.'));
+
+    $fields['changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Changed'))
+      ->setDescription(t('The time that the entity was last edited.'));
+
+    return $fields;
+  }
+
+}

--- a/src/Entity/RunComparisonInterface.php
+++ b/src/Entity/RunComparisonInterface.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Drupal\web_page_archive\Entity;
+
+use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\Core\Entity\RevisionableInterface;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\user\EntityOwnerInterface;
+
+/**
+ * Provides an interface for defining Web page archive run entities.
+ *
+ * @ingroup web_page_archive
+ */
+interface RunComparisonInterface extends RevisionableInterface, RevisionLogInterface, EntityChangedInterface, EntityOwnerInterface {
+
+  /**
+   * Gets the Web page archive run name.
+   *
+   * @return string
+   *   Name of the Web page archive run.
+   */
+  public function getName();
+
+  /**
+   * Sets the Web page archive run name.
+   *
+   * @param string $name
+   *   The Web page archive run name.
+   *
+   * @return \Drupal\web_page_archive\Entity\RunComparisonInterface
+   *   The called run comparison entity.
+   */
+  public function setName($name);
+
+  /**
+   * Gets the Web page archive run creation timestamp.
+   *
+   * @return int
+   *   Creation timestamp of the Web page archive run.
+   */
+  public function getCreatedTime();
+
+  /**
+   * Sets the Web page archive run creation timestamp.
+   *
+   * @param int $timestamp
+   *   The Web page archive run creation timestamp.
+   *
+   * @return \Drupal\web_page_archive\Entity\RunComparisonInterface
+   *   The called run comparison entity.
+   */
+  public function setCreatedTime($timestamp);
+
+  /**
+   * Gets the Web page archive run revision creation timestamp.
+   *
+   * @return int
+   *   The UNIX timestamp of when this revision was created.
+   */
+  public function getRevisionCreationTime();
+
+  /**
+   * Sets the Web page archive run revision creation timestamp.
+   *
+   * @param int $timestamp
+   *   The UNIX timestamp of when this revision was created.
+   *
+   * @return \Drupal\web_page_archive\Entity\RunComparisonInterface
+   *   The called run comparison entity.
+   */
+  public function setRevisionCreationTime($timestamp);
+
+  /**
+   * Gets the Web page archive run revision author.
+   *
+   * @return \Drupal\user\UserInterface
+   *   The user entity for the revision author.
+   */
+  public function getRevisionUser();
+
+  /**
+   * Sets the Web page archive run revision author.
+   *
+   * @param int $uid
+   *   The user ID of the revision author.
+   *
+   * @return \Drupal\web_page_archive\Entity\RunComparisonInterface
+   *   The called run comparison entity.
+   */
+  public function setRevisionUserId($uid);
+
+  /**
+   * Retrieves the first run entity for the comparison.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The first run entity for this comparison.
+   */
+  public function getRun1();
+
+  /**
+   * Retrieves the first run entity id for the comparison.
+   *
+   * @return int
+   *   The first run entity id for this comparison.
+   */
+  public function getRun1Id();
+
+  /**
+   * Retrieves the second run entity for the comparison.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The second run entity for this comparison.
+   */
+  public function getRun2();
+
+  /**
+   * Retrieves the first run entity id for the comparison.
+   *
+   * @return int
+   *   The first run entity id for this comparison.
+   */
+  public function getRun2Id();
+
+  /**
+   * Retrieves both run entities as an array.
+   *
+   * @return RunComparisonInterface[]
+   *   Retrieves both run comparison entities.
+   */
+  public function getRunEntities();
+
+  /**
+   * Retrieves a queue for the run comparison object.
+   *
+   * @return \Drupal\Core\Queue\QueueInterface
+   *   The queue for this run comparison.
+   */
+  public function getQueue();
+
+  /**
+   * Retrieves list of comparison results.
+   *
+   * @return array
+   *   A list of comparison results.
+   */
+  public function getResults();
+
+}

--- a/src/Entity/Sql/RunComparisonStorage.php
+++ b/src/Entity/Sql/RunComparisonStorage.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\web_page_archive\Entity\Sql;
+
+use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\web_page_archive\Entity\RunComparisonInterface;
+
+/**
+ * Defines the storage handler class for Web page archive run entities.
+ *
+ * This extends the base storage class, adding required special handling for
+ * Web page archive run entities.
+ *
+ * @ingroup web_page_archive
+ */
+class RunComparisonStorage extends SqlContentEntityStorage implements RunComparisonStorageInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function revisionIds(RunComparisonInterface $entity) {
+    return $this->database->query(
+      'SELECT vid FROM {run_comparison_revision} WHERE id=:id ORDER BY vid',
+      [':id' => $entity->id()]
+    )->fetchCol();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fullRevisionList() {
+    return $this->database->query(
+      'SELECT vid, name, revision_created FROM {run_comparison_revision} ORDER BY vid'
+    )->fetchAllAssoc('vid');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userRevisionIds(AccountInterface $account) {
+    return $this->database->query(
+      'SELECT vid FROM {run_comparison_field_revision} WHERE uid = :uid ORDER BY vid',
+      [':uid' => $account->id()]
+    )->fetchCol();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function countDefaultLanguageRevisions(RunComparisonInterface $entity) {
+    return $this->database->query('SELECT COUNT(*) FROM {run_comparison_field_revision} WHERE id = :id AND default_langcode = 1', [':id' => $entity->id()])
+      ->fetchField();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function clearRevisionsLanguage(LanguageInterface $language) {
+    return $this->database->update('run_comparison_revision')
+      ->fields(['langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED])
+      ->condition('langcode', $language->getId())
+      ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addResult(RunComparisonInterface $entity, array $result) {
+    $required_keys = [
+      'delta1',
+      'delta2',
+      'has_left',
+      'has_right',
+      'langcode',
+      'results',
+      'run1',
+      'run2',
+      'url',
+      'variance',
+    ];
+    foreach ($required_keys as $required_key) {
+      if (!isset($result[$required_key])) {
+        throw new \Exception($this->t('@key is required', ['@key' => $required_key]));
+      }
+    }
+
+    $values = [
+      'revision_id' => $entity->getRevisionId(),
+      'run1' => (int) $result['run1'],
+      'run2' => (int) $result['run2'],
+      'delta1' => (int) $result['delta1'],
+      'delta2' => (int) $result['delta2'],
+      'has_left' => (int) $result['has_left'],
+      'has_right' => (int) $result['has_right'],
+      'langcode' => $result['langcode'],
+      'url' => $result['url'],
+      'variance' => (float) $result['variance'],
+      'results' => $result['results'],
+      'timestamp' => \Drupal::time()->getRequestTime(),
+    ];
+
+    $this->database
+      ->insert('web_page_archive_run_comparison_details')
+      ->fields(array_keys($values))
+      ->values(array_values($values))
+      ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResults(RunComparisonInterface $entity) {
+    $query = $this->database->query(
+      'SELECT * FROM {web_page_archive_run_comparison_details} WHERE revision_id=:revision_id ORDER BY url',
+      [':revision_id' => $entity->getRevisionId()]);
+    $rows = [];
+    while ($row = $query->fetchAssoc()) {
+      $rows[] = $row;
+    }
+
+    return $rows;
+  }
+
+}

--- a/src/Entity/Sql/RunComparisonStorageInterface.php
+++ b/src/Entity/Sql/RunComparisonStorageInterface.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\web_page_archive\Entity\Sql;
+
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\web_page_archive\Entity\RunComparisonInterface;
+
+/**
+ * Defines the storage handler class for run comparison entities.
+ *
+ * This extends the base storage class, adding required special handling for
+ * run comparison entities.
+ *
+ * @ingroup web_page_archive
+ */
+interface RunComparisonStorageInterface extends ContentEntityStorageInterface {
+
+  /**
+   * Gets a list of Web page archive run revision IDs for a specific run.
+   *
+   * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $entity
+   *   The run comparison entity.
+   *
+   * @return int[]
+   *   Web page archive run revision IDs (in ascending order).
+   */
+  public function revisionIds(RunComparisonInterface $entity);
+
+  /**
+   * Gets a list of revision IDs having a given user as run author.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user entity.
+   *
+   * @return int[]
+   *   Web page archive run revision IDs (in ascending order).
+   */
+  public function userRevisionIds(AccountInterface $account);
+
+  /**
+   * Counts the number of revisions in the default language.
+   *
+   * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $entity
+   *   The run comparison entity.
+   *
+   * @return int
+   *   The number of revisions in the default language.
+   */
+  public function countDefaultLanguageRevisions(RunComparisonInterface $entity);
+
+  /**
+   * Unsets the language for all Web page archive run with the given language.
+   *
+   * @param \Drupal\Core\Language\LanguageInterface $language
+   *   The language object.
+   */
+  public function clearRevisionsLanguage(LanguageInterface $language);
+
+  /**
+   * Adds a result for the specified run comparison entity.
+   *
+   * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $entity
+   *   The run comparison entity.
+   * @param mixed[] $result
+   *   An array containing the result data.
+   */
+  public function addResult(RunComparisonInterface $entity, array $result);
+
+  /**
+   * Retrieves the results for a specified run comparison entity.
+   *
+   * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $entity
+   *   The run comparison entity.
+   *
+   * @return mixed[]
+   *   A list of matching results.
+   */
+  public function getResults(RunComparisonInterface $entity);
+
+}

--- a/src/Entity/Sql/WebPageArchiveRunStorage.php
+++ b/src/Entity/Sql/WebPageArchiveRunStorage.php
@@ -30,6 +30,15 @@ class WebPageArchiveRunStorage extends SqlContentEntityStorage implements WebPag
   /**
    * {@inheritdoc}
    */
+  public function fullRevisionList() {
+    return $this->database->query(
+      'SELECT vid, name, revision_created FROM {web_page_archive_run_revision} ORDER BY vid'
+    )->fetchAllAssoc('vid');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function userRevisionIds(AccountInterface $account) {
     return $this->database->query(
       'SELECT vid FROM {web_page_archive_run_field_revision} WHERE uid = :uid ORDER BY vid',

--- a/src/Entity/Sql/WebPageArchiveRunStorageInterface.php
+++ b/src/Entity/Sql/WebPageArchiveRunStorageInterface.php
@@ -29,6 +29,14 @@ interface WebPageArchiveRunStorageInterface extends ContentEntityStorageInterfac
   public function revisionIds(WebPageArchiveRunInterface $entity);
 
   /**
+   * Gets a list of all web page archive run revision IDs and labels.
+   *
+   * @return array
+   *   Web page archive run revision ids and labels.
+   */
+  public function fullRevisionList();
+
+  /**
    * Gets a list of revision IDs having a given user as run author.
    *
    * @param \Drupal\Core\Session\AccountInterface $account

--- a/src/Entity/WebPageArchiveRun.php
+++ b/src/Entity/WebPageArchiveRun.php
@@ -20,6 +20,7 @@ use Drupal\web_page_archive\Controller\CleanupController;
  *   label = @Translation("Web page archive run"),
  *   handlers = {
  *     "storage" = "Drupal\web_page_archive\Entity\Sql\WebPageArchiveRunStorage",
+ *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "views_data" = "Drupal\web_page_archive\Entity\WebPageArchiveRunViewsData",
  *
@@ -212,6 +213,13 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
   public function setCaptureUtilities(array $array) {
     $this->set('capture_utilities', $array);
     return $this;
+  }
+
+  /**
+   * Retrieves list of captured data.
+   */
+  public function getCapturedArray() {
+    return $this->get('field_captures');
   }
 
   /**

--- a/src/Form/RunComparisonDeleteForm.php
+++ b/src/Form/RunComparisonDeleteForm.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\web_page_archive\Form;
+
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+
+/**
+ * Provides a form for deleting run comparison entities.
+ *
+ * @ingroup web_page_archive
+ */
+class RunComparisonDeleteForm extends ContentEntityDeleteForm {
+
+
+}

--- a/src/Form/RunComparisonForm.php
+++ b/src/Form/RunComparisonForm.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\web_page_archive\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Uuid\Php;
+use Drupal\web_page_archive\Controller\RunComparisonController;
+use Drupal\web_page_archive\Entity\Sql\WebPageArchiveRunStorageInterface;
+use Drupal\web_page_archive\Entity\Sql\RunComparisonStorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Compares web page archive capture runs.
+ */
+class RunComparisonForm extends FormBase {
+
+  private $runStorage;
+  private $runComparisonStorage;
+  private $uuid;
+
+  /**
+   * Constructs a base class for web page archive add and edit forms.
+   *
+   * @param \Drupal\web_page_archive\Entity\Sql\WebPageArchiveRunStorageInterface $run_storage
+   *   The run entity storage service.
+   * @param \Drupal\web_page_archive\Entity\Sql\RunComparisonStorageInterface $run_comparison_storage
+   *   The run comparison entity storage service.
+   * @param \Drupal\Component\Uuid\Php $uuid
+   *   The UUID generator service.
+   */
+  public function __construct(WebPageArchiveRunStorageInterface $run_storage, RunComparisonStorageInterface $run_comparison_storage, Php $uuid) {
+    $this->runStorage = $run_storage;
+    $this->runComparisonStorage = $run_comparison_storage;
+    $this->uuid = $uuid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $entity_type_manager = $container->get('entity_type.manager');
+    return new static(
+      $entity_type_manager->getStorage('web_page_archive_run'),
+      $entity_type_manager->getStorage('wpa_run_comparison'),
+      $container->get('uuid')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'web_page_archive_compare_runs';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Next'),
+        '#button_type' => 'primary',
+      ],
+    ];
+
+    $form['run1'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Run #1'),
+      '#description' => $this->t('Specify the revision ID for the run you wish to use as your baseline.'),
+      '#autocomplete_route_name' => 'web_page_archive.autocomplete.runs',
+      '#required' => TRUE,
+    ];
+    $form['run2'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Run #2'),
+      '#description' => $this->t('Specify the revision ID for the run you wish to compare against.'),
+      '#autocomplete_route_name' => 'web_page_archive.autocomplete.runs',
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Ensure both specified runs are valid.
+    $run1 = $this->runStorage->loadRevision($form_state->getValue('run1'));
+    if (!isset($run1)) {
+      $form_state->setErrorByName('run1', $this->t('Run #1 must reference a valid web page archive run revision id.'));
+    }
+    $run2 = $this->runStorage->loadRevision($form_state->getValue('run2'));
+    if (!isset($run2)) {
+      $form_state->setErrorByName('run2', $this->t('Run #2 must reference a valid web page archive run revision id.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $run1 = $this->runStorage->loadRevision($form_state->getValue('run1'));
+    $run2 = $this->runStorage->loadRevision($form_state->getValue('run2'));
+    $labels = [
+      '@label1' => RunComparisonController::generateRevisionLabel($run1->getRevisionId(), $run1->label(), $run1->getRevisionCreationTime()),
+      '@label2' => RunComparisonController::generateRevisionLabel($run2->getRevisionId(), $run2->label(), $run2->getRevisionCreationTime()),
+    ];
+
+    $data = [
+      'user_id' => \Drupal::currentUser()->id(),
+      'name' => $this->t('@label1 -vs- @label2', $labels),
+      'uuid' => $this->uuid->generate(),
+      'run1' => $run1->getRevisionId(),
+      'run2' => $run2->getRevisionId(),
+      'status' => 1,
+    ];
+    $run_comparison = $this->runComparisonStorage->create($data);
+    $run_comparison->save();
+
+    RunComparisonController::enqueueRunComparisons($run_comparison);
+    RunComparisonController::setBatch($run_comparison);
+
+    $form_state->setRedirect('web_page_archive.compare.summary', ['wpa_run_comparison' => $run_comparison->id()]);
+  }
+
+}

--- a/src/Plugin/CaptureResponse/UriCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/UriCaptureResponse.php
@@ -27,6 +27,13 @@ class UriCaptureResponse extends CaptureResponseBase {
   /**
    * {@inheritdoc}
    */
+  public static function getId() {
+    return 'wpa_uri_capture_response';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCaptureSize() {
     // TODO: What to do if remote URL instead of local file path?
     if (!is_readable($this->getContent())) {

--- a/src/Plugin/CaptureResponseBase.php
+++ b/src/Plugin/CaptureResponseBase.php
@@ -57,6 +57,21 @@ abstract class CaptureResponseBase implements CaptureResponseInterface {
   /**
    * Set response content.
    *
+   * @param string $id
+   *   The response content.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CaptureResponseInterface
+   *   Reference to self.
+   */
+  protected function setId($id) {
+    $this->id = $id;
+
+    return $this;
+  }
+
+  /**
+   * Set response content.
+   *
    * @param string $content
    *   The response content.
    *
@@ -114,6 +129,33 @@ abstract class CaptureResponseBase implements CaptureResponseInterface {
    */
   public function getCaptureSize() {
     return 0;
+  }
+
+  /**
+   * Retrieves an id for the capture response type.
+   */
+  public static function getId() {
+    // We should warn if this method is not overridden. This will allow for
+    // graceful handling of any existing capture responses. In next major
+    // release, this should get converted to an abstract method.
+    $class = get_called_class();
+    \Drupal::logger('web_page_archive')
+      ->notice('@class should override the getId() method.', ['@class' => $class]);
+    return 'wpa_capture_response';
+  }
+
+  /**
+   * Performs a comparison two responses.
+   */
+  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b) {
+    // We should warn if this method is not overridden. This will allow for
+    // graceful handling of any existing capture responses. In next major
+    // release, this should get converted to an abstract method.
+    $class = get_called_class();
+    \Drupal::logger('web_page_archive')
+      ->notice('@class should override the compare() method.', ['@class' => $class]);
+
+    return \Drupal::service('web_page_archive.compare.response')->getEmptyCompareResponse();
   }
 
   /**

--- a/src/Plugin/CompareResponse/EmptyCompareResponse.php
+++ b/src/Plugin/CompareResponse/EmptyCompareResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CompareResponse;
+
+use Drupal\web_page_archive\Plugin\CompareResponseBase;
+
+/**
+ * The response when no comparison could be performed.
+ *
+ * This should only ever get used by the CaptureResponseBase as this is meant
+ * to indicate that a capture response has failed to implement compare().
+ */
+class EmptyCompareResponse extends CompareResponseBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_empty_compare_response';
+  }
+
+  /**
+   * Renders this response.
+   */
+  public function renderable(array $options = []) {
+    return ['#markup' => $this->t('No comparison could be performed.')];
+  }
+
+}

--- a/src/Plugin/CompareResponse/NoVariantCompareResponse.php
+++ b/src/Plugin/CompareResponse/NoVariantCompareResponse.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CompareResponse;
+
+/**
+ * The response that indicates no variant was specified.
+ */
+class NoVariantCompareResponse extends VarianceCompareResponse {
+
+  private $isLeft = FALSE;
+  private $isRight = FALSE;
+
+  /**
+   * Constructs a new NoVariantCompareResponse object.
+   *
+   * Something vs nothing is always 100% different, so extending the
+   * VarianceCompareResponse and setting the variance value to 100 makes sense.
+   */
+  public function __construct() {
+    parent::__construct(100);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_no_variant_compare_response';
+  }
+
+  /**
+   * Indicates if the response is only on the left side of a comparison.
+   *
+   * @return bool
+   *   A boolean indicated if response is on the left side of the comparison.
+   */
+  public function isLeft() {
+    return $this->isLeft;
+  }
+
+  /**
+   * Indicates if the response is only on the right side of a comparison.
+   *
+   * @return bool
+   *   A boolean indicated if response is on the right side of the comparison.
+   */
+  public function isRight() {
+    return $this->isRight;
+  }
+
+  /**
+   * Marks as being a left only response.
+   *
+   * @return Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   Returns self.
+   */
+  public function markLeft() {
+    $this->isLeft = TRUE;
+    $this->isRight = FALSE;
+
+    return $this;
+  }
+
+  /**
+   * Marks as being a right only response.
+   *
+   * @return Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   Returns self.
+   */
+  public function markRight() {
+    $this->isLeft = FALSE;
+    $this->isRight = TRUE;
+
+    return $this;
+  }
+
+  /**
+   * Renders this response.
+   */
+  public function renderable(array $options = []) {
+    return ['#markup' => $this->t('Capture only occurs in one run.')];
+  }
+
+}

--- a/src/Plugin/CompareResponse/SameCompareResponse.php
+++ b/src/Plugin/CompareResponse/SameCompareResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CompareResponse;
+
+/**
+ * The response that indicates the variance threshold for a response.
+ */
+class SameCompareResponse extends VarianceCompareResponse {
+
+  /**
+   * Constructs a new SameCompareResponse object.
+   *
+   * Two things that are the same have zero variance, so extending the
+   * VarianceCompareResponse and setting the variance value to zero makes sense.
+   */
+  public function __construct() {
+    parent::__construct('0');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_same_compare_response';
+  }
+
+  /**
+   * Renders this response.
+   */
+  public function renderable(array $options = []) {
+    return ['#markup' => $this->t('Captures are identical.')];
+  }
+
+}

--- a/src/Plugin/CompareResponse/VarianceCompareResponse.php
+++ b/src/Plugin/CompareResponse/VarianceCompareResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CompareResponse;
+
+use Drupal\web_page_archive\Plugin\CompareResponseBase;
+
+/**
+ * The response that indicates the variance threshold for a response.
+ */
+class VarianceCompareResponse extends CompareResponseBase {
+
+  /**
+   * Creates a new VarianceCompareResponse object.
+   */
+  public function __construct($variance) {
+    $this->variance = (float) $variance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_variance_compare_response';
+  }
+
+  /**
+   * Renders this response.
+   */
+  public function renderable(array $options = []) {
+    return ['#markup' => $this->t('There is a @variance% difference between the two captures.', ['@variance' => $this->variance])];
+  }
+
+}

--- a/src/Plugin/CompareResponseBase.php
+++ b/src/Plugin/CompareResponseBase.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Base class for capture responses.
+ */
+abstract class CompareResponseBase implements CompareResponseInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The response content.
+   *
+   * @var string
+   */
+  protected $content = '';
+
+  /**
+   * The variance value.
+   *
+   * @var string
+   */
+  protected $variance = -1;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContent() {
+    return $this->content;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setContent($content) {
+    $this->content = $content;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getVariance() {
+    return round($this->variance, 1);
+  }
+
+  /**
+   * Retrieves the ID of the compare response.
+   */
+  abstract public static function getId();
+
+  /**
+   * Renders this response.
+   */
+  abstract public function renderable(array $options = []);
+
+}

--- a/src/Plugin/CompareResponseFactory.php
+++ b/src/Plugin/CompareResponseFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+use Drupal\web_page_archive\Plugin\CompareResponse\EmptyCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\NoVariantCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse;
+
+/**
+ * Service that returns compare response objects.
+ */
+class CompareResponseFactory {
+
+  /**
+   * Retrieves an empty compare response.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   An EmptyCompareResponse object.
+   */
+  public function getEmptyCompareResponse() {
+    return new EmptyCompareResponse();
+  }
+
+  /**
+   * Retrieves no variant compare response.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   A NoVariantCompareResponse object.
+   */
+  public function getNoVariantCompareResponse() {
+    return new NoVariantCompareResponse();
+  }
+
+  /**
+   * Retrieves an same compare response.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   An SameCompareResponse object.
+   */
+  public function getSameCompareResponse() {
+    return new SameCompareResponse();
+  }
+
+  /**
+   * Retrieves a variance compare response.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   An VarianceCompareResponse object.
+   */
+  public function getVarianceCompareResponse($variance) {
+    return new VarianceCompareResponse($variance);
+  }
+
+}

--- a/src/Plugin/CompareResponseInterface.php
+++ b/src/Plugin/CompareResponseInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+/**
+ * Defines an interface for Compare responses.
+ */
+interface CompareResponseInterface {
+
+  /**
+   * Retrieve content.
+   *
+   * @return string
+   *   Stringified content.
+   */
+  public function getContent();
+
+  /**
+   * Set response content.
+   *
+   * @param string $content
+   *   The response content.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CaptureResponseInterface
+   *   Reference to self.
+   */
+  public function setContent($content);
+
+  /**
+   * Retrieves the variance to 1 significant digit.
+   *
+   * @return float
+   *   A percentage value indicating how much two capture responses vary.
+   */
+  public function getVariance();
+
+}

--- a/src/Plugin/QueueWorker/CompareQueueWorker.php
+++ b/src/Plugin/QueueWorker/CompareQueueWorker.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\web_page_archive\Controller\RunComparisonController;
+
+/**
+ * Provides functionality for running compare jobs.
+ *
+ * @QueueWorker(
+ *   id = "web_page_archive_compare",
+ *   title = @Translation("Web Page Archive Compare"),
+ * )
+ */
+class CompareQueueWorker extends QueueWorkerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    // Check all required keys are provided.
+    $required = [
+      'compare_class',
+      'left_id',
+      'right_id',
+      'run_comparison',
+      'runs',
+      'url',
+    ];
+    foreach ($required as $key) {
+      if (!isset($data[$key])) {
+        throw new \Exception("$key is required");
+      }
+    }
+
+    $response_factory = \Drupal::service('web_page_archive.compare.response');
+
+    // Check if left and right are set.
+    $data['has_left'] = isset($data['runs'][$data['left_id']]);
+    $data['has_right'] = isset($data['runs'][$data['right_id']]);
+
+    // Populate delta values.
+    $data['delta1'] = isset($data['runs'][$data['left_id']]) ? array_keys($data['runs'][$data['left_id']])[0] : 0;
+    $data['delta2'] = isset($data['runs'][$data['right_id']]) ? array_keys($data['runs'][$data['right_id']])[0] : 0;
+
+    // If has both left and right, we need to perform a comparison.
+    if ($data['has_left'] && $data['has_right']) {
+      $left_response = reset($data['runs'][$data['left_id']])['capture_response'];
+      $right_response = reset($data['runs'][$data['right_id']])['capture_response'];
+      $response = call_user_func([$data['compare_class'], 'compare'], $left_response, $right_response);
+    }
+    elseif ($data['has_left']) {
+      $response = $response_factory->getNoVariantCompareResponse()->markLeft();
+    }
+    elseif ($data['has_right']) {
+      $response = $response_factory->getNoVariantCompareResponse()->markRight();
+    }
+    else {
+      throw new \Exception('Invalid comparison detected.');
+    }
+    $data['variance'] = $response->getVariance();
+    $data['compare_response'] = $response;
+
+    RunComparisonController::markCompareComplete($data);
+    return $response;
+  }
+
+}

--- a/tests/src/Kernel/Controller/RunComparisonControllerTest.php
+++ b/tests/src/Kernel/Controller/RunComparisonControllerTest.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Controller;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\web_page_archive\Controller\RunComparisonController;
+use Drupal\web_page_archive\Plugin\CaptureResponse\UriCaptureResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests the functionality of the run comparison controller.
+ *
+ * @group web_page_archive
+ */
+class RunComparisonControllerTest extends EntityKernelTestBase {
+
+  protected $controller;
+  protected $runComparisonStorage;
+  protected $runStorage;
+  protected $fieldTypeManager;
+  protected $fieldFormatterManager;
+  protected $entityFieldManager;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'field',
+    'node',
+    'system',
+    'views',
+    'web_page_archive',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    date_default_timezone_set('Antarctica/Troll');
+    $this->installSchema('web_page_archive', 'web_page_archive_capture_details');
+    $this->installSchema('web_page_archive', 'web_page_archive_run_comparison_details');
+    $this->installEntitySchema('web_page_archive_run');
+    $this->installEntitySchema('wpa_run_comparison');
+    $this->installConfig(['web_page_archive']);
+    $this->controller = RunComparisonController::create($this->container);
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    $this->runStorage = $entity_type_manager->getStorage('web_page_archive_run');
+    $this->runComparisonStorage = $entity_type_manager->getStorage('wpa_run_comparison');
+    $this->fieldTypeManager = $this->container->get('plugin.manager.field.field_type');
+    $this->fieldFormatterManager = $this->container->get('plugin.manager.field.formatter');
+    $this->entityFieldManager = $this->container->get('entity_field.manager');
+  }
+
+  /**
+   * Creates a run entity with the specified number of revisions.
+   */
+  private function getRunEntity($name, $revision_ct, $start_time = 1513860000) {
+    // Create initial entity.
+    $data = [
+      'name' => $name,
+      'success_ct' => 5,
+    ];
+    $run_entity = $this->runStorage->create($data);
+    $run_entity->setRevisionCreationTime($start_time);
+    $run_entity->save();
+
+    // Create additional revisions.
+    for ($i = 1; $i <= $revision_ct; $i++) {
+      $run_entity->setNewRevision(TRUE);
+      $run_entity->setRevisionCreationTime($start_time + $i);
+      $run_entity->save();
+    }
+
+    return $run_entity;
+  }
+
+  /**
+   * Creates a capture field with the specified results.
+   */
+  private function getCaptureField($value) {
+    $field_definitions = $this->entityFieldManager->getFieldDefinitions('web_page_archive_run', 'web_page_archive_run');
+    $configuration = [
+      'name' => 'field_captures',
+      'parent' => NULL,
+      'field_definition' => $field_definitions['field_captures'],
+    ];
+    $field = $this->fieldTypeManager->createInstance('web_page_archive_capture', $configuration);
+
+    $field->setValue($value);
+    return serialize($field->getValue());
+  }
+
+  /**
+   * Tests RunComparisonController::generateRevisionLabel().
+   */
+  public function testGenerateRevisionLabel() {
+    $label = $this->controller->generateRevisionLabel(5, 'My Capture Run', 1387637515);
+    $expected = 'My Capture Run: 2013-12-21 14:51:55 (5)';
+    $this->assertEquals($expected, $label);
+
+    $label = $this->controller->generateRevisionLabel(993, 'Another Run', 15939944323);
+    $expected = 'Another Run: 2475-02-12 02:18:43 (993)';
+    $this->assertEquals($expected, $label);
+  }
+
+  /**
+   * Tests RunComparisonController::handleRunAutocomplete().
+   */
+  public function testHandleRunAutocomplete() {
+    // Create three run entities.
+    $entity = $this->getRunEntity('My run entity', 3);
+    $entity2 = $this->getRunEntity('Yet another run entity', 2);
+    $entity3 = $this->getRunEntity('Non-matching run', 6);
+
+    // Get all revision ids for the first two runs.
+    $revision_ids = $this->runStorage->revisionIds($entity);
+    $revision_ids_2 = $this->runStorage->revisionIds($entity2);
+
+    // Confirm 3 additional revisions were created (i.e. 4 total).
+    $this->assertEquals(4, count($revision_ids));
+
+    // Partial-matching string should return all matching revisions.
+    $request = new Request(['q' => 'entity']);
+    $response = $this->controller->handleRunAutocomplete($request);
+    $expected = [];
+    foreach ($revision_ids as $second => $revision_id) {
+      $expected[] = [
+        'label' => "My run entity: 2017-12-21 12:40:0{$second} ({$revision_id})",
+        'value' => $revision_id,
+      ];
+    }
+    foreach ($revision_ids_2 as $second => $revision_id) {
+      $expected[] = [
+        'label' => "Yet another run entity: 2017-12-21 12:40:0{$second} ({$revision_id})",
+        'value' => $revision_id,
+      ];
+    }
+
+    $this->assertEquals($expected, json_decode($response->getContent(), TRUE));
+
+    // Full string match should return non-empty list.
+    $request = new Request(['q' => "My run entity: 2017-12-21 12:40:02 ({$revision_ids[2]})"]);
+    $response = $this->controller->handleRunAutocomplete($request);
+    $expected = [
+      [
+        'label' => "My run entity: 2017-12-21 12:40:02 ({$revision_ids[2]})",
+        'value' => $revision_ids[2],
+      ],
+    ];
+
+    $this->assertEquals($expected, json_decode($response->getContent(), TRUE));
+
+    // Non-matching string should return empty list.
+    $request = new Request(['q' => 'Invalid String']);
+    $response = $this->controller->handleRunAutocomplete($request);
+    $expected = [];
+    $this->assertEquals($expected, json_decode($response->getContent(), TRUE));
+
+    // Empty string should return empty list.
+    $request = new Request(['q' => '']);
+    $response = $this->controller->handleRunAutocomplete($request);
+    $expected = [];
+    $this->assertEquals($expected, json_decode($response->getContent(), TRUE));
+
+    // Unspecified string should return empty list.
+    $request = new Request();
+    $response = $this->controller->handleRunAutocomplete($request);
+    $expected = [];
+    $this->assertEquals($expected, json_decode($response->getContent(), TRUE));
+  }
+
+  /**
+   * Tests RunComparisionController::generateRunMatrix().
+   */
+  public function testGenerateRunMatrix() {
+    // Create a run entity and then load the first two runs.
+    $entity = $this->getRunEntity('My run entity', 2);
+    list($run1_id, $run2_id) = $this->runStorage->revisionIds($entity);
+    $entity_runs = [
+      $this->runStorage->loadRevision($run1_id),
+      $this->runStorage->loadRevision($run2_id),
+    ];
+
+    // Evaluate a few capture response.
+    $capture_results = [
+      [
+        'capture_response' => new UriCaptureResponse('You can do anything at zombo.com.', 'http://www.zombo.com'),
+        'capture_url' => 'http://www.zombo.com',
+        'delta' => 4,
+      ],
+      [
+        'capture_response' => new UriCaptureResponse('Find all the things', 'https://www.google.com'),
+        'capture_url' => 'https://www.google.com',
+        'delta' => 13,
+      ],
+    ];
+
+    // Set run capture data.
+    $entity_runs[0]->setCapturedArray([
+      $this->getCaptureField($capture_results[0]),
+      $this->getCaptureField($capture_results[1]),
+    ])->save();
+    $entity_runs[1]->setCapturedArray([
+      $this->getCaptureField($capture_results[0]),
+    ])->save();
+
+    // Evaluate the expected matrix is generated.
+    $expected = [
+      'wpa_uri_capture_response' => [
+        'http://www.zombo.com' => [
+          $run1_id => [4 => $capture_results[0]],
+          $run2_id => [4 => $capture_results[0]],
+        ],
+        'https://www.google.com' => [
+          $run1_id => [13 => $capture_results[1]],
+        ],
+      ],
+    ];
+    $this->assertEquals($expected, $this->controller->generateRunMatrix($entity_runs));
+  }
+
+  /**
+   * Tests RunComparisionController::enqueueRunComparisons().
+   */
+  public function testEnqueueRunComparisons() {
+    // Create a run entity and then load the first two runs.
+    $entity = $this->getRunEntity('My run entity', 2);
+    list($run1_id, $run2_id) = $this->runStorage->revisionIds($entity);
+
+    // Create a run comparison.
+    $data = [
+      'run1' => $run1_id,
+      'run2' => $run2_id,
+      'name' => 'Compare job',
+    ];
+    $run_comparison = $this->runComparisonStorage->create($data);
+    $run_comparison->save();
+
+    // Evaluate a few capture response.
+    $capture_results = [
+      [
+        'capture_response' => new UriCaptureResponse('You can do anything at zombo.com.', 'http://www.zombo.com'),
+        'capture_url' => 'http://www.zombo.com',
+        'delta' => 4,
+      ],
+      [
+        'capture_response' => new UriCaptureResponse('Find all the things', 'https://www.google.com'),
+        'capture_url' => 'https://www.google.com',
+        'delta' => 13,
+      ],
+    ];
+
+    // Set run capture data.
+    $run_comparison->getRun1()->setCapturedArray([
+      $this->getCaptureField($capture_results[0]),
+      $this->getCaptureField($capture_results[1]),
+    ])->save();
+    $run_comparison->getRun2()->setCapturedArray([
+      $this->getCaptureField($capture_results[0]),
+    ])->save();
+
+    // Enqueue the comparison and make sure there are 2 items in the queue.
+    $this->controller->enqueueRunComparisons($run_comparison);
+    $queue = $run_comparison->getQueue();
+    $this->assertEquals(2, $queue->numberOfItems());
+
+    // Attempt to process the next item in the queue.
+    $this->assertTrue($this->controller->batchProcess($run_comparison));
+    $this->assertEquals(1, $queue->numberOfItems());
+
+    // Attempt to process the next item in the queue.
+    $this->assertTrue($this->controller->batchProcess($run_comparison));
+    $this->assertEquals(0, $queue->numberOfItems());
+
+    $expected = [
+      [
+        'run1' => $run1_id,
+        'run2' => $run2_id,
+        'delta1' => '4',
+        'delta2' => '4',
+        'has_left' => '1',
+        'has_right' => '1',
+        'revision_id' => $run_comparison->getRevisionId(),
+        'url' => 'http://www.zombo.com',
+        'variance' => '-1',
+      ],
+      [
+        'run1' => $run1_id,
+        'run2' => $run2_id,
+        'delta1' => '13',
+        'delta2' => '0',
+        'has_left' => '1',
+        'has_right' => '0',
+        'revision_id' => $run_comparison->getRevisionId(),
+        'url' => 'https://www.google.com',
+        'variance' => '100',
+      ],
+    ];
+    $this->assertArraySubset($expected, $run_comparison->getResults());
+  }
+
+  /**
+   * Tests RunComparisonController::markCompareComplete().
+   */
+  public function testMarkCompareComplete() {
+    // Create a run comparison.
+    $data = [
+      'run1' => 47,
+      'run2' => 93,
+      'name' => 'Compare job',
+    ];
+    $run_comparison = $this->runComparisonStorage->create($data);
+    $run_comparison->save();
+
+    // Create initial array.
+    $data = [
+      'url' => 'http://www.homestarrunner.com',
+      'delta1' => 50,
+      'delta2' => 150,
+      'has_left' => TRUE,
+      'has_right' => FALSE,
+      'left_id' => 47,
+      'right_id' => 93,
+      'run_comparison' => $run_comparison,
+      'variance' => 53,
+    ];
+    $this->controller->markCompareComplete($data);
+
+    $expected = [
+      [
+        'run1' => 47,
+        'run2' => 93,
+        'delta1' => '50',
+        'delta2' => '150',
+        'has_left' => '1',
+        'has_right' => '0',
+        'revision_id' => $run_comparison->getRevisionId(),
+        'url' => 'http://www.homestarrunner.com',
+        'variance' => '53',
+      ],
+    ];
+    $this->assertArraySubset($expected, $run_comparison->getResults());
+  }
+
+}

--- a/tests/src/Unit/Plugin/CompareResponse/EmptyCompareResponseTest.php
+++ b/tests/src/Unit/Plugin/CompareResponse/EmptyCompareResponseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CompareResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\web_page_archive\Plugin\CompareResponse\EmptyCompareResponse;
+
+/**
+ * @coversDefaultClass \Drupal\web_page_archive\Plugin\CompareResponse\EmptyCompareResponse
+ *
+ * @group web_page_archive
+ */
+class EmptyCompareResponseTest extends UnitTestCase {
+
+  /**
+   * Tests that the variance is -1.
+   */
+  public function testVarianceIsNegativeOne() {
+    $response = new EmptyCompareResponse();
+    $this->assertEquals(-1, $response->getVariance());
+  }
+
+}

--- a/tests/src/Unit/Plugin/CompareResponse/NoVariantCompareResponseTest.php
+++ b/tests/src/Unit/Plugin/CompareResponse/NoVariantCompareResponseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CompareResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\web_page_archive\Plugin\CompareResponse\NoVariantCompareResponse;
+
+/**
+ * @coversDefaultClass \Drupal\web_page_archive\Plugin\CompareResponse\NoVariantCompareResponse
+ *
+ * @group web_page_archive
+ */
+class NoVariantCompareResponseTest extends UnitTestCase {
+
+  /**
+   * Tests that a right response, can't be left.
+   */
+  public function testRightResponseCantBeLeft() {
+    $response = new NoVariantCompareResponse();
+    $response->markLeft();
+    $response->markRight();
+    $this->assertFalse($response->isLeft());
+    $this->assertTrue($response->isRight());
+  }
+
+  /**
+   * Tests that a left response, can't be right.
+   */
+  public function testLeftResponseCantBeRight() {
+    $response = new NoVariantCompareResponse();
+    $response->markRight();
+    $response->markLeft();
+    $this->assertTrue($response->isLeft());
+    $this->assertFalse($response->isRight());
+  }
+
+  /**
+   * Tests that the variance is 100 if unmarked.
+   */
+  public function testUnmarkedResponseVarianceIs100() {
+    $response = new NoVariantCompareResponse();
+    $this->assertEquals(100, $response->getVariance());
+  }
+
+  /**
+   * Tests that the variance is 100 if marked left.
+   */
+  public function testLeftResponseVarianceIs100() {
+    $response = new NoVariantCompareResponse();
+    $response->markLeft();
+    $this->assertEquals(100, $response->getVariance());
+  }
+
+  /**
+   * Tests that the variance is 100 if marked right.
+   */
+  public function testRightResponseVarianceIs100() {
+    $response = new NoVariantCompareResponse();
+    $response->markRight();
+    $this->assertEquals(100, $response->getVariance());
+  }
+
+}

--- a/tests/src/Unit/Plugin/CompareResponse/SameCompareResponseTest.php
+++ b/tests/src/Unit/Plugin/CompareResponse/SameCompareResponseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CompareResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse;
+
+/**
+ * @coversDefaultClass \Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse
+ *
+ * @group web_page_archive
+ */
+class SameCompareResponseTest extends UnitTestCase {
+
+  /**
+   * Tests that the variance is 0.
+   */
+  public function testVarianceIsZero() {
+    $response = new SameCompareResponse();
+    $this->assertEquals(0, $response->getVariance());
+  }
+
+}

--- a/tests/src/Unit/Plugin/CompareResponse/VarianceCompareResponseTest.php
+++ b/tests/src/Unit/Plugin/CompareResponse/VarianceCompareResponseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CompareResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse;
+
+/**
+ * @coversDefaultClass \Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse
+ *
+ * @group web_page_archive
+ */
+class VarianceCompareResponseTest extends UnitTestCase {
+
+  /**
+   * Tests that the variance is set by the constructor.
+   */
+  public function testUnmarkedResponseVarianceIsSetByTheConstructor() {
+    $response = new VarianceCompareResponse(53);
+    $this->assertEquals(53, $response->getVariance());
+  }
+
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Database\Database;
+use Drupal\Core\Entity\ContentEntityType;
 use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
@@ -325,9 +326,34 @@ function web_page_archive_update_8008() {
  * Adds wpa_run_comparison and wpa_run_comparison_revision tables.
  */
 function web_page_archive_update_8009() {
-  $entity_type_manager = \Drupal::entityTypeManager();
   $update_manager = \Drupal::entityDefinitionUpdateManager();
-  $definition = $entity_type_manager->getDefinition('wpa_run_comparison');
+  $definition = new ContentEntityType([
+    'id' => 'wpa_run_comparison',
+    'label' => 'Web Page Archive Run Comparison',
+    'handlers' => [
+      'storage' => 'Drupal\web_page_archive\Entity\Sql\RunComparisonStorage',
+      'list_builder' => 'Drupal\Core\Entity\EntityListBuilder',
+      'view_builder' => 'Drupal\Core\Entity\EntityViewBuilder',
+      'form' => [
+        'delete' => 'Drupal\web_page_archive\Form\RunComparisonDeleteForm',
+      ],
+    ],
+    'base_table' => 'wpa_run_comparison',
+    'revision_table' => 'wpa_run_comparison_revision',
+    'revision_data_table' => 'wpa_run_comparison_field_revision',
+    'admin_permission' => 'administer web page archive',
+    'fieldable' => TRUE,
+    'entity_keys' => [
+      'id' => 'id',
+      'revision' => 'vid',
+      'label' => 'name',
+      'uuid' => 'uuid',
+      'uid' => 'user_id',
+      'langcode' => 'langcode',
+      'status' => 'status',
+    ],
+    'field_ui_base_route' => 'wpa_run_comparison.settings',
+  ]);
   $update_manager->installEntityType($definition);
 }
 

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Database\Database;
 use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
@@ -88,6 +89,100 @@ function web_page_archive_schema() {
       ],
     ],
     'primary key' => ['revision_id', 'delta', 'langcode'],
+  ];
+
+  $schema['web_page_archive_run_comparison_details'] = [
+    'description' => 'Stores detailed comparison information',
+    'fields' => [
+      'revision_id' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {wpa_run_comparison}.vid.',
+      ],
+      'run1' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision}.vid.',
+      ],
+      'run2' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision}.vid.',
+      ],
+      'delta1' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision__field_captures}.delta.',
+      ],
+      'delta2' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision__field_captures}.delta.',
+      ],
+      'has_left' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'A boolean indicating whether this comparison has a left value.',
+      ],
+      'has_right' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'A boolean indicating whether this comparison has a right value.',
+      ],
+      'langcode' => [
+        'type' => 'varchar_ascii',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Maps to {wpa_run_comparison}.langcode.',
+      ],
+      'url' => [
+        'type' => 'varchar_ascii',
+        'length' => 1023,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The shared key with used for comparisons.',
+      ],
+      'variance' => [
+        'type' => 'float',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'How much variance exists between the two compare items.',
+      ],
+      'results' => [
+        'type' => 'blob',
+        'description' => 'Serialized comparison results.',
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Timestamp when the comparison was performed.',
+      ],
+    ],
+    'primary key' => [
+      'revision_id',
+      'run1',
+      'run2',
+      'delta1',
+      'delta2',
+      'langcode',
+    ],
   ];
 
   return $schema;
@@ -224,4 +319,116 @@ function web_page_archive_update_8008() {
   $config->set('system.node_path', '');
   $config->set('system.npm_path', '');
   $config->save();
+}
+
+/**
+ * Adds wpa_run_comparison and wpa_run_comparison_revision tables.
+ */
+function web_page_archive_update_8009() {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $definition = $entity_type_manager->getDefinition('wpa_run_comparison');
+  $update_manager->installEntityType($definition);
+}
+
+/**
+ * Adds web_page_archive_run_comparison_details table.
+ */
+function web_page_archive_update_8010() {
+  $spec = [
+    'description' => 'Stores detailed comparison information',
+    'fields' => [
+      'revision_id' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {wpa_run_comparison}.vid.',
+      ],
+      'run1' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision}.vid.',
+      ],
+      'run2' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision}.vid.',
+      ],
+      'delta1' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision__field_captures}.delta.',
+      ],
+      'delta2' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {web_page_archive_run_revision__field_captures}.delta.',
+      ],
+      'has_left' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'A boolean indicating whether this comparison has a left value.',
+      ],
+      'has_right' => [
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'A boolean indicating whether this comparison has a right value.',
+      ],
+      'langcode' => [
+        'type' => 'varchar_ascii',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Maps to {wpa_run_comparison}.langcode.',
+      ],
+      'url' => [
+        'type' => 'varchar_ascii',
+        'length' => 1023,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The shared key with used for comparisons.',
+      ],
+      'variance' => [
+        'type' => 'float',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'How much variance exists between the two compare items.',
+      ],
+      'results' => [
+        'type' => 'blob',
+        'description' => 'Serialized comparison results.',
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Timestamp when the comparison was performed.',
+      ],
+    ],
+    'primary key' => [
+      'revision_id',
+      'run1',
+      'run2',
+      'delta1',
+      'delta2',
+      'langcode',
+    ],
+  ];
+
+  $schema = Database::getConnection()->schema();
+  $schema->createTable('web_page_archive_run_comparison_details', $spec);
 }

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -6,6 +6,35 @@ entity.web_page_archive.collection:
   requirements:
     _permission: 'view web page archive results'
 
+web_page_archive.compare:
+  path: 'admin/config/system/web-page-archive/compare'
+  defaults:
+    _form: '\Drupal\web_page_archive\Form\RunComparisonForm'
+    _title: 'Compare Runs'
+  requirements:
+    _permission: 'view web page archive results'
+
+web_page_archive.compare.summary:
+  path: 'admin/config/system/web-page-archive/compare/{wpa_run_comparison}'
+  options:
+    parameters:
+      wpa_run_comparison:
+        type: entity:wpa_run_comparison
+  defaults:
+    _controller: '\Drupal\web_page_archive\Controller\RunComparisonController::summary'
+    _title_callback: '\Drupal\web_page_archive\Controller\RunComparisonController::summaryTitle'
+  requirements:
+    _permission: 'view web page archive results'
+    run_comparison: '^[a-zA-Z0-9_]+'
+
+web_page_archive.autocomplete.runs:
+  path: 'admin/config/system/web-page-archive/compare/runs'
+  defaults:
+    _controller: '\Drupal\web_page_archive\Controller\RunComparisonController::handleRunAutocomplete'
+    _format: json
+  requirements:
+    _access: 'TRUE'
+
 web_page_archive_settings:
   path: 'admin/config/system/web-page-archive/settings'
   defaults:

--- a/web_page_archive.services.yml
+++ b/web_page_archive.services.yml
@@ -23,3 +23,7 @@ services:
     arguments: ['@lock', '@state', '@datetime.time', '@config.factory']
     tags:
       - { name: cron }
+  web_page_archive.compare.response:
+    class: Drupal\web_page_archive\Plugin\CompareResponseFactory
+    tags:
+      - { name: factory }


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2931285
Parent Issue: https://www.drupal.org/project/web_page_archive/issues/2894273

This PR introduces some of the UI and basic functionality needing for performing diffs.

- Capture Responses should all now have a `getId()` method returning a unique ID for that capture response.
- Introduced the `wpa_run_comparison` content entity type. 
  - Most of the functionality lives in `RunComparisonController`
  - Comparison results are stored in `web_page_archive_run_comparison_details` db table.
  - `hook_schema()` and new update hooks created to install the content type and build the necessary db tables.
- New form at /admin/config/web-page-archive/compare allows you to specify multiple runs (i.e. web_page_archive_run revision ids), for comparison. 
  - These revisions can either be from the same job, or separate jobs. It doesn't matter.
  - The fields use autocompletion to help lookup specific runs.
  - Upon submitting the form, a new `wpa_run_comparison` entity is created, and a batch job is initiated to perform all of the comparisons.
  - Note: I have opted not to create a link to this route yet anywhere in the admin panel.  As this is only one task amongst several tasks, I'm gonna wait until the link is actually useful for users to add it in. 
- Each comparison generates a "Compare Response" which is indicated by `CompareResponseInterface` or `CompareResponseBase`.
  - I created a `EmptyCompareResponse` for when a capture response fails to provide a comparison method.
  - I created a `NoVariantCompareResponse` for when a compared item only exists in one list, not both. (i.e. if /some/page is only captured in the second run, not the first one). 
  - I created a `SameCompareResponse` for when two captured items are identical.
  - I created a `VarianceCompareResponse` which attributes a numeric percentage to the difference between two responses. `SameCompareResponse` and `NoVariantCompareResponse` actually extend this.
  - I also created a `CompareResponseFactory` for generating the response with a single service, instead of having to deal with a bunch of different classes.
- I added test coverage for the major methods in the `RunComparisonController` as well as some basic unit tests for the capture responses. 

