### PR TITLE
Issue #2932529 by WidgetsBurritos: Diff Summary View

### DIFF
--- a/config/install/views.view.web_page_archive_previous_comparisons.yml
+++ b/config/install/views.view.web_page_archive_previous_comparisons.yml
@@ -1,0 +1,284 @@
+uuid: 964444cb-dece-4a5f-85da-f698833cb543
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+    - web_page_archive
+id: web_page_archive_previous_comparisons
+label: 'Web Page Archive Previous Comparisons'
+module: views
+description: ''
+tag: ''
+base_table: wpa_run_comparison
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'view web page archive results'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: table
+      row:
+        type: fields
+      fields:
+        name:
+          id: name
+          table: wpa_run_comparison
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: null
+          entity_field: name
+          plugin_id: field
+        revision_created:
+          id: revision_created
+          table: wpa_run_comparison_revision
+          field: revision_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Time
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp_ago
+          settings:
+            granularity: 2
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: wpa_run_comparison
+          entity_field: revision_created
+          plugin_id: field
+        operations:
+          id: operations
+          table: wpa_run_comparison
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: wpa_run_comparison
+          plugin_id: entity_operations
+      filters: {  }
+      sorts: {  }
+      title: 'Web Page Archive Previous Comparisons'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/system/web-page-archive/compare/history
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/install/views.view.web_page_archive_run_comparison_summary.yml
+++ b/config/install/views.view.web_page_archive_run_comparison_summary.yml
@@ -1,0 +1,581 @@
+uuid: cb0cb41a-6b13-4c6c-962a-27a0a12a3f17
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+    - web_page_archive
+id: web_page_archive_run_comparison_summary
+label: 'Web Page Archive Run Comparison Summary'
+module: views
+description: 'Comparison summary between two runs.'
+tag: ''
+base_table: wpa_run_comparison
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'view web page archive results'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: true
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 20
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: false
+          override: true
+          sticky: true
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            field_captures_value: field_captures_value
+            field_captures_value_1: field_captures_value_1
+            variance: variance
+            results: variance
+          info:
+            field_captures_value:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            field_captures_value_1:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            variance:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            results:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        field_captures_value:
+          id: field_captures_value
+          table: web_page_archive_run_revision__field_captures
+          field: field_captures_value
+          relationship: run1_1
+          group_type: group
+          admin_label: ''
+          label: 'Run #1'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          format: unserialized
+          key: ''
+          plugin_id: web_page_archive_serialized_capture
+        field_captures_value_1:
+          id: field_captures_value_1
+          table: web_page_archive_run_revision__field_captures
+          field: field_captures_value
+          relationship: run2_1
+          group_type: group
+          admin_label: ''
+          label: 'Run #2'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          format: unserialized
+          key: ''
+          plugin_id: web_page_archive_serialized_capture
+        variance:
+          id: variance
+          table: web_page_archive_run_comparison_details
+          field: variance
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: Variance
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<div class="wpa-comparison-variance">{{ variance }}</div>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          plugin_id: standard
+        results:
+          id: results
+          table: web_page_archive_run_comparison_details
+          field: results
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: 'Comparison Results'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          format: unserialized
+          key: ''
+          plugin_id: web_page_archive_serialized_comparison_results
+      filters:
+        url:
+          id: url
+          table: web_page_archive_run_comparison_details
+          field: url
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: url_op
+            label: URL
+            description: ''
+            use_operator: true
+            operator: url_op
+            identifier: url
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        has_left:
+          id: has_left
+          table: web_page_archive_run_comparison_details
+          field: has_left
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Exists in Run #1?'
+            description: ''
+            use_operator: false
+            operator: has_left_op
+            identifier: has_left
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: 'Has Left?'
+            description: null
+            identifier: has_left
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          plugin_id: boolean
+        has_right:
+          id: has_right
+          table: web_page_archive_run_comparison_details
+          field: has_right
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Exists in Run #2?'
+            description: ''
+            use_operator: false
+            operator: has_right_op
+            identifier: has_right
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+      sorts: {  }
+      title: 'Web Page Archive Run Comparison Summary'
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          content: 'Displaying @start - @end of @total'
+          plugin_id: result
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No comparison results found.'
+            format: basic_html
+          plugin_id: text
+      relationships:
+        run1:
+          id: run1
+          table: wpa_run_comparison
+          field: run1
+          relationship: none
+          group_type: group
+          admin_label: 'The first web page archive run related to this comparison entity.'
+          required: true
+          entity_type: wpa_run_comparison
+          entity_field: run1
+          plugin_id: standard
+        run2:
+          id: run2
+          table: wpa_run_comparison
+          field: run2
+          relationship: none
+          group_type: group
+          admin_label: 'The second web page archive run related to this comparison entity.'
+          required: true
+          entity_type: wpa_run_comparison
+          entity_field: run2
+          plugin_id: standard
+        vid:
+          id: vid
+          table: wpa_run_comparison
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: 'The web page archive run comparison details.'
+          required: true
+          entity_type: wpa_run_comparison
+          entity_field: vid
+          plugin_id: standard
+        run1_1:
+          id: run1_1
+          table: web_page_archive_run_comparison_details
+          field: run1
+          relationship: vid
+          group_type: group
+          admin_label: 'Individual capture results.'
+          required: false
+          plugin_id: standard
+        run2_1:
+          id: run2_1
+          table: web_page_archive_run_comparison_details
+          field: run2
+          relationship: vid
+          group_type: group
+          admin_label: 'Individual capture results.'
+          required: false
+          plugin_id: standard
+      arguments:
+        id:
+          id: id
+          table: wpa_run_comparison
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: wpa_run_comparison
+          entity_field: id
+          plugin_id: numeric
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/config/system/web-page-archive/compare/%
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -144,3 +144,25 @@ views.filter.web_page_archive_capture_utility_filter:
           sequence:
             type: views.filter.group_item.in_operator
             label: 'Group item'
+
+views.field.web_page_archive_serialized_capture:
+  type: views_field
+  label: 'Serialized Capture Results'
+  mapping:
+    format:
+      type: string
+      label: 'Display format'
+    key:
+      type: string
+      label: 'Which key should be displayed'
+
+views.field.web_page_archive_serialized_comparison_results:
+  type: views_field
+  label: 'Serialized Comparison Results'
+  mapping:
+    format:
+      type: string
+      label: 'Display format'
+    key:
+      type: string
+      label: 'Which key should be displayed'

--- a/src/Controller/RunComparisonController.php
+++ b/src/Controller/RunComparisonController.php
@@ -234,20 +234,4 @@ class RunComparisonController extends ControllerBase {
     }
   }
 
-  /**
-   * Displays the run summary for the specified run comparison object.
-   */
-  public static function summary($wpa_run_comparison) {
-    return [
-      '#markup' => 'TODO: Add something here',
-    ];
-  }
-
-  /**
-   * Displays the summary title for the specified run comparison object.
-   */
-  public static function summaryTitle($wpa_run_comparison) {
-    return $wpa_run_comparison->label();
-  }
-
 }

--- a/src/Entity/RunComparison.php
+++ b/src/Entity/RunComparison.php
@@ -16,11 +16,12 @@ use Drupal\user\UserInterface;
  *
  * @ContentEntityType(
  *   id = "wpa_run_comparison",
- *   label = @Translation("Web Page Archive Run Comparison"),
+ *   label = @Translation("Web page archive run comparison"),
  *   handlers = {
  *     "storage" = "Drupal\web_page_archive\Entity\Sql\RunComparisonStorage",
  *     "list_builder" = "Drupal\Core\Entity\EntityListBuilder",
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "views_data" = "Drupal\web_page_archive\Entity\RunComparisonViewsData",
  *     "form" = {
  *       "delete" = "Drupal\web_page_archive\Form\RunComparisonDeleteForm",
  *     },
@@ -30,6 +31,12 @@ use Drupal\user\UserInterface;
  *   revision_data_table = "wpa_run_comparison_field_revision",
  *   admin_permission = "administer web page archive",
  *   fieldable = TRUE,
+ *   links = {
+ *     "canonical" = "/admin/config/system/web-page-archive/compare/{wpa_run_comparison}",
+ *     "add-form" = "/admin/config/system/web-page-archive/compare",
+ *     "delete-form" = "/admin/config/system/web-page-archive/compare/{wpa_run_comparison}/delete",
+ *     "collection" = "/admin/config/system/web-page-archive/compare/history"
+ *   },
  *   entity_keys = {
  *     "id" = "id",
  *     "revision" = "vid",

--- a/src/Entity/RunComparisonViewsData.php
+++ b/src/Entity/RunComparisonViewsData.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\web_page_archive\Entity;
+
+use Drupal\views\EntityViewsData;
+
+/**
+ * Provides views data for run comparison entities.
+ */
+class RunComparisonViewsData extends EntityViewsData {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getViewsData() {
+    $data = parent::getViewsData();
+
+    // Setup run relationships.
+    $data['wpa_run_comparison']['run1']['relationship']['id'] = 'standard';
+    $data['wpa_run_comparison']['run1']['relationship']['base'] = 'web_page_archive_run_revision';
+    $data['wpa_run_comparison']['run1']['relationship']['base field'] = 'vid';
+    $data['wpa_run_comparison']['run1']['relationship']['title'] = $this->t('Web Page Archive Run #1');
+    $data['wpa_run_comparison']['run1']['relationship']['label'] = $this->t('The first web page archive run related to this comparison entity.');
+
+    $data['wpa_run_comparison']['run2']['relationship']['id'] = 'standard';
+    $data['wpa_run_comparison']['run2']['relationship']['base'] = 'web_page_archive_run_revision';
+    $data['wpa_run_comparison']['run2']['relationship']['base field'] = 'vid';
+    $data['wpa_run_comparison']['run2']['relationship']['title'] = $this->t('Web Page Archive Run #2');
+    $data['wpa_run_comparison']['run2']['relationship']['label'] = $this->t('The second web page archive run related to this comparison entity.');
+
+    // Setup relationship to comparison details table.
+    $data['wpa_run_comparison']['vid']['relationship']['id'] = 'standard';
+    $data['wpa_run_comparison']['vid']['relationship']['base'] = 'web_page_archive_run_comparison_details';
+    $data['wpa_run_comparison']['vid']['relationship']['base field'] = 'revision_id';
+    $data['wpa_run_comparison']['vid']['relationship']['title'] = $this->t('Web Page Archive Run Comparison Details');
+    $data['wpa_run_comparison']['vid']['relationship']['label'] = $this->t('The web page archive run comparison details.');
+
+    // Expose web_page_archive_run_comparison_details table and fields to views.
+    $data['web_page_archive_run_comparison_details'] = [];
+    $data['web_page_archive_run_comparison_details']['table'] = [];
+    $data['web_page_archive_run_comparison_details']['table']['group'] = t('Web page archive run comparison');
+    $data['web_page_archive_run_comparison_details']['url'] = [
+      'title' => $this->t('Comparison URL'),
+      'help' => $this->t('The URL being compared.'),
+      'argument' => ['id' => 'string'],
+      'field' => ['id' => 'standard'],
+      'filter' => ['id' => 'string'],
+      'sort' => ['id' => 'standard'],
+    ];
+    $data['web_page_archive_run_comparison_details']['results'] = [
+      'title' => $this->t('Comparison Results'),
+      'help' => $this->t('Comparison results between two captures.'),
+      'argument' => ['id' => 'standard'],
+      'field' => ['id' => 'web_page_archive_serialized_comparison_results'],
+      'filter' => ['id' => 'numeric'],
+      'sort' => ['id' => 'standard'],
+    ];
+    $data['web_page_archive_run_comparison_details']['variance'] = [
+      'title' => $this->t('Variance'),
+      'help' => $this->t('Variance between two captures.'),
+      'argument' => ['id' => 'numeric'],
+      'field' => ['id' => 'web_page_archive_variance'],
+      'filter' => ['id' => 'numeric'],
+      'sort' => ['id' => 'standard'],
+    ];
+    $data['web_page_archive_run_comparison_details']['has_left'] = [
+      'title' => $this->t('Has Left?'),
+      'help' => $this->t('Boolean indicating whether or not the URL exists in the left portion of the comparison.'),
+      'argument' => ['id' => 'numeric'],
+      'field' => ['id' => 'standard'],
+      'filter' => ['id' => 'boolean'],
+      'sort' => ['id' => 'standard'],
+    ];
+    $data['web_page_archive_run_comparison_details']['has_right'] = [
+      'title' => $this->t('Has Right?'),
+      'help' => $this->t('Boolean indicating whether or not the URL exists in the left portion of the comparison.'),
+      'argument' => ['id' => 'numeric'],
+      'field' => ['id' => 'standard'],
+      'filter' => ['id' => 'boolean'],
+      'sort' => ['id' => 'standard'],
+    ];
+
+    // Link comparison details to capture results.
+    $data['web_page_archive_run_comparison_details']['run1']['relationship']['id'] = 'standard';
+    $data['web_page_archive_run_comparison_details']['run1']['relationship']['base'] = 'web_page_archive_run_revision__field_captures';
+    $data['web_page_archive_run_comparison_details']['run1']['relationship']['base field'] = 'revision_id';
+    $data['web_page_archive_run_comparison_details']['run1']['relationship']['title'] = $this->t('Web Page Archive Run #1 Capture Results');
+    $data['web_page_archive_run_comparison_details']['run1']['relationship']['label'] = $this->t('Run #1 capture results.');
+    $data['web_page_archive_run_comparison_details']['run1']['relationship']['extra'] = [
+      ['left_field' => 'has_left', 'value' => 1],
+      ['field' => 'delta', 'left_field' => 'delta1'],
+      ['field' => 'langcode', 'left_field' => 'langcode'],
+    ];
+
+    $data['web_page_archive_run_comparison_details']['run2']['relationship']['id'] = 'standard';
+    $data['web_page_archive_run_comparison_details']['run2']['relationship']['base'] = 'web_page_archive_run_revision__field_captures';
+    $data['web_page_archive_run_comparison_details']['run2']['relationship']['base field'] = 'revision_id';
+    $data['web_page_archive_run_comparison_details']['run2']['relationship']['title'] = $this->t('Web Page Archive Run #2 Capture Results');
+    $data['web_page_archive_run_comparison_details']['run2']['relationship']['label'] = $this->t('Run #2 capture results.');
+    $data['web_page_archive_run_comparison_details']['run2']['relationship']['extra'] = [
+      ['left_field' => 'has_right', 'value' => 1],
+      ['field' => 'delta', 'left_field' => 'delta2'],
+      ['field' => 'langcode', 'left_field' => 'langcode'],
+    ];
+
+    return $data;
+  }
+
+}

--- a/src/Form/RunComparisonDeleteForm.php
+++ b/src/Form/RunComparisonDeleteForm.php
@@ -3,6 +3,8 @@
 namespace Drupal\web_page_archive\Form;
 
 use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
  * Provides a form for deleting run comparison entities.
@@ -11,5 +13,39 @@ use Drupal\Core\Entity\ContentEntityDeleteForm;
  */
 class RunComparisonDeleteForm extends ContentEntityDeleteForm {
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete %name?', ['%name' => $this->entity->label()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.wpa_run_comparison.collection');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->entity->delete();
+
+    drupal_set_message($this->t('content @type: deleted @label.', [
+      '@type' => $this->entity->bundle(),
+      '@label' => $this->entity->label(),
+    ]));
+
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
 
 }

--- a/src/Form/RunComparisonForm.php
+++ b/src/Form/RunComparisonForm.php
@@ -125,7 +125,7 @@ class RunComparisonForm extends FormBase {
     RunComparisonController::enqueueRunComparisons($run_comparison);
     RunComparisonController::setBatch($run_comparison);
 
-    $form_state->setRedirect('web_page_archive.compare.summary', ['wpa_run_comparison' => $run_comparison->id()]);
+    $form_state->setRedirect('entity.wpa_run_comparison.canonical', ['wpa_run_comparison' => $run_comparison->id()]);
   }
 
 }

--- a/src/Plugin/views/field/SerializedComparisonResults.php
+++ b/src/Plugin/views/field/SerializedComparisonResults.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\Serialized;
+use Drupal\views\ResultRow;
+
+/**
+ * Field handler to show data of serialized fields.
+ *
+ * @ViewsField("web_page_archive_serialized_comparison_results")
+ */
+class SerializedComparisonResults extends Serialized {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $value = $values->{$this->field_alias};
+
+    if ($this->options['format'] == 'unserialized') {
+      $options = unserialize($value);
+      if (isset($options['compare_response'])) {
+        return $options['compare_response']->renderable($options);
+      }
+    }
+    return $this->t('Could not render results');
+  }
+
+}

--- a/src/Plugin/views/field/Variance.php
+++ b/src/Plugin/views/field/Variance.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+
+/**
+ * Field handler to show data of serialized fields.
+ *
+ * @ViewsField("web_page_archive_variance")
+ */
+class Variance extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $value = (float) $this->getValue($values);
+
+    // If negative, return an empty string.
+    if ($value < 0) {
+      return '';
+    }
+
+    // If non-negative, display variance as a percentage.
+    return $this->t('Variance: @variance%', ['@variance' => $value]);
+  }
+
+}

--- a/tests/src/Functional/RunComparisonTest.php
+++ b/tests/src/Functional/RunComparisonTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests web page archive.
+ *
+ * @group web_page_archive
+ */
+class RunComparisonTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public $profile = 'minimal';
+
+  /**
+   * Authorized Admin User.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $authorizedAdminUser;
+
+  /**
+   * Authorized View User.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $authorizedReadOnlyUser;
+
+  /**
+   * Unauthorized User.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $unauthorizedUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'web_page_archive',
+    'wpa_skeleton_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->authorizedAdminUser = $this->drupalCreateUser([
+      'administer web page archive',
+      'view web page archive results',
+    ]);
+    $this->authorizedReadOnlyUser = $this->drupalCreateUser([
+      'view web page archive results',
+    ]);
+    $this->unauthorizedUser = $this->drupalCreateUser([
+      'administer nodes',
+    ]);
+    $this->runStorage = \Drupal::service('entity_type.manager')->getStorage('web_page_archive_run');
+    $this->comparisonStorage = \Drupal::service('entity_type.manager')->getStorage('wpa_run_comparison');
+  }
+
+  /**
+   * Tests that a new comparison shows row results on summary page.
+   */
+  public function testComparisonHasRow() {
+    $assert = $this->assertSession();
+
+    // Create dummy run and comparison entities.
+    $run1 = $this->runStorage->create(['success_ct' => 2]);
+    $run1->save();
+    $run2 = $this->runStorage->create(['success_ct' => 1]);
+    $run2->save();
+
+    $data = [
+      'run1' => $run1->id(),
+      'run2' => $run2->id(),
+    ];
+    $comparison = $this->comparisonStorage->create($data);
+    $comparison->save();
+
+    $data = [
+      'delta1' => 1,
+      'delta2' => 2,
+      'has_left' => 1,
+      'has_right' => 1,
+      'langcode' => 'es',
+      'results' => serialize([]),
+      'run1' => $run1->id(),
+      'run2' => $run2->id(),
+      'url' => 'http://www.zombo.com',
+      'variance' => 23.3,
+    ];
+    $this->comparisonStorage->addResult($comparison, $data);
+
+    $data = [
+      'delta1' => 2,
+      'delta2' => 3,
+      'has_left' => 1,
+      'has_right' => 1,
+      'langcode' => 'es',
+      'results' => serialize([]),
+      'run1' => $run1->id(),
+      'run2' => $run2->id(),
+      'url' => 'http://www.homestarrunner.com',
+      'variance' => -1,
+    ];
+    $this->comparisonStorage->addResult($comparison, $data);
+
+    // Login.
+    $this->drupalLogin($this->authorizedAdminUser);
+    $this->drupalGet("admin/config/system/web-page-archive/compare/{$comparison->id()}");
+
+    $assert->pageTextContains('Operator');
+    $assert->pageTextContains('URL');
+    $assert->pageTextContains('Exists in Run #1?');
+    $assert->pageTextContains('Exists in Run #2?');
+    $assert->pageTextContains('Variance: 23.3%');
+    $assert->pageTextNotContains('Variance: -1%');
+
+    /*
+     * TODO: This will change once UriCaptureResponse provides compare().
+     *
+     * @see https://www.drupal.org/project/web_page_archive/issues/2932533
+     */
+    $assert->pageTextContains('Could not render results');
+  }
+
+  /**
+   * Functional test to ensure authorized admin access.
+   */
+  public function testAdminUser() {
+    $assert = $this->assertSession();
+
+    // Create a dummy entity.
+    $data = [];
+    $comparison = $this->comparisonStorage->create($data);
+    $comparison->save();
+
+    // Login.
+    $this->drupalLogin($this->authorizedAdminUser);
+
+    $urls = [
+      'admin/config/system/web-page-archive/compare',
+      'admin/config/system/web-page-archive/compare/history',
+      "admin/config/system/web-page-archive/compare/{$comparison->id()}",
+      "admin/config/system/web-page-archive/compare/{$comparison->id()}/delete",
+    ];
+    foreach ($urls as $url) {
+      $this->drupalGet($url);
+      $this->assertResponse(Response::HTTP_OK);
+    }
+  }
+
+  /**
+   * Functional test to ensure authorized read-only access.
+   */
+  public function testReadOnlyUser() {
+    $assert = $this->assertSession();
+
+    // Create a dummy entity.
+    $data = [];
+    $comparison = $this->comparisonStorage->create($data);
+    $comparison->save();
+
+    // Login.
+    $this->drupalLogin($this->authorizedReadOnlyUser);
+
+    $permitted_urls = [
+      'admin/config/system/web-page-archive/compare',
+      'admin/config/system/web-page-archive/compare/history',
+      "admin/config/system/web-page-archive/compare/{$comparison->id()}",
+    ];
+    foreach ($permitted_urls as $url) {
+      $this->drupalGet($url);
+      $this->assertResponse(Response::HTTP_OK);
+    }
+
+    $forbidden_urls = [
+      "admin/config/system/web-page-archive/compare/{$comparison->id()}/delete",
+    ];
+    foreach ($forbidden_urls as $url) {
+      $this->drupalGet($url);
+      $this->assertResponse(Response::HTTP_FORBIDDEN);
+    }
+  }
+
+  /**
+   * Functional test to ensure authorized access only.
+   */
+  public function testUnauthorizedUser() {
+    $assert = $this->assertSession();
+
+    // Create a dummy entity.
+    $data = [];
+    $comparison = $this->comparisonStorage->create($data);
+    $comparison->save();
+
+    // Login.
+    $this->drupalLogin($this->unauthorizedUser);
+
+    $urls = [
+      'admin/config/system/web-page-archive/compare',
+      'admin/config/system/web-page-archive/compare/history',
+      "admin/config/system/web-page-archive/compare/{$comparison->id()}",
+      "admin/config/system/web-page-archive/compare/{$comparison->id()}/delete",
+    ];
+    foreach ($urls as $url) {
+      $this->drupalGet($url);
+      $this->assertResponse(Response::HTTP_FORBIDDEN);
+    }
+  }
+
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -458,3 +458,19 @@ function web_page_archive_update_8010() {
   $schema = Database::getConnection()->schema();
   $schema->createTable('web_page_archive_run_comparison_details', $spec);
 }
+
+/**
+ * Adds run comparison summary and history views.
+ */
+function web_page_archive_update_8011() {
+  $path = drupal_get_path('module', 'web_page_archive') . '/config/install';
+  $source = new FileStorage($path);
+  $config_storage = \Drupal::service('config.storage');
+  $views = [
+    'views.view.web_page_archive_previous_comparisons',
+    'views.view.web_page_archive_run_comparison_summary',
+  ];
+  foreach ($views as $view) {
+    $config_storage->write($view, $source->read($view));
+  }
+}

--- a/web_page_archive.links.task.yml
+++ b/web_page_archive.links.task.yml
@@ -15,3 +15,13 @@ entity.web_page_archive.collection.prepare_uninstall:
   base_route: entity.web_page_archive.collection
   route_name: entity.web_page_archive.collection.prepare_uninstall
   weight: -4
+
+web_page_archive.compare:
+  title: 'Compare Runs'
+  route_name: web_page_archive.compare
+  base_route: web_page_archive.compare
+
+web_page_archive.compare.history:
+  title: 'Previous Run Comparisons'
+  route_name: entity.wpa_run_comparison.collection
+  base_route: web_page_archive.compare

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -14,18 +14,28 @@ web_page_archive.compare:
   requirements:
     _permission: 'view web page archive results'
 
-web_page_archive.compare.summary:
+entity.wpa_run_comparison.canonical:
   path: 'admin/config/system/web-page-archive/compare/{wpa_run_comparison}'
   options:
     parameters:
       wpa_run_comparison:
         type: entity:wpa_run_comparison
-  defaults:
-    _controller: '\Drupal\web_page_archive\Controller\RunComparisonController::summary'
-    _title_callback: '\Drupal\web_page_archive\Controller\RunComparisonController::summaryTitle'
   requirements:
     _permission: 'view web page archive results'
-    run_comparison: '^[a-zA-Z0-9_]+'
+    wpa_run_comparison: '^[a-zA-Z0-9_]+'
+
+entity.wpa_run_comparison.collection:
+  path: 'admin/config/system/web-page-archive/compare/history'
+  requirements:
+    _permission: 'view web page archive results'
+
+entity.wpa_run_comparison.delete_form:
+  path: 'admin/config/system/web-page-archive/compare/{wpa_run_comparison}/delete'
+  defaults:
+    _entity_form: 'wpa_run_comparison.delete'
+    _title: 'Delete Run Comparison'
+  requirements:
+    _permission: 'administer web page archive'
 
 web_page_archive.autocomplete.runs:
   path: 'admin/config/system/web-page-archive/compare/runs'


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2932529

- Introduce new `Run Comparison Summary` and `Previous Run Comparisons` views.
  - `Previous Run Comparisons` has a list of previously ran comparisons, with an option to view or delete those comparisons.
  - `Run Comparison Summary` is the summary page for an individual comparison. 
  - New `web_page_archive_serialized_comparison_results` and `web_page_archive_variance` views fields have been added for custom rendering of this data.
  - Schema has been updated to support new serialized fields.
  - `getViewsData()` has been implemented to setup necessary relationships in views.
  - `web_page_archive_update_8011()` installs the new views inside an existing system.
- Local tasks have been added for the main `Compare Runs` form, and the `Previous Run Comparisons` page. 
- Route changes:
  - Renamed `web_page_archive.compare.summary` to `entity.wpa_run_comparison.canonical`
  - Added `entity.wpa_run_comparison.collection` route. 
  - Added `entity.wpa_run_comparison.delete_form`
  - All of these route changes are meant to match the addition of the `links` property to the `wpa_run_comparison` entity type.
  - Removed unnecessary references to controller methods in `entity.wpa_run_comparison.canonical` as these are now getting handled directly by views.
- New Functional Tests:
  - `testComparisonHasRow()` tests a comparison generates a new row in the views summary as expected.
  - `testAdminUser()`, `testReadOnlyUser()`, `testUnauthorizedUser()` were added to test route permissions related to comparison URLs. This ended up being beneficial as the tests helped me identify a few places where permissions were incorrect in the system itself.

---

Here are some screenshots of the functionality in action. (Note: the third column wont get fleshed out until [Issue #2932532: Comparison Criteria for ScreenshotCaptureResponse](https://www.drupal.org/project/web_page_archive/issues/2932532) is completed).

**Capture exists in both runs:**
<img width="1023" alt="screen shot 2017-12-29 at 12 13 05 am" src="https://user-images.githubusercontent.com/5263371/34430672-20761920-ec2d-11e7-891d-2ecf931f815b.png">

**Capture exists in first run only:** 
<img width="1022" alt="screen shot 2017-12-29 at 12 13 17 am" src="https://user-images.githubusercontent.com/5263371/34430673-2087df52-ec2d-11e7-9d13-2574fcb65361.png">

**Capture exists in second run only:**
<img width="1022" alt="screen shot 2017-12-29 at 12 13 24 am" src="https://user-images.githubusercontent.com/5263371/34430674-209977c6-ec2d-11e7-840f-326ce731e264.png">

**Previous Run Comparisons page:**
![image](https://user-images.githubusercontent.com/5263371/34430984-38fa1df4-ec30-11e7-9c50-03e4ac4505b5.png)
