### PR TITLE
Issue #2932530 by WidgetsBurritos: Diff Base Path Stripping Option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ before_script:
   - drupal-ti before_script
 
 script:
-  - phpcs --standard=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme --ignore=vendor/,*.md $TRAVIS_BUILD_DIR
+  - phpcs --standard=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme --ignore=vendor/,*.md,*.txt $TRAVIS_BUILD_DIR
   - $HOME/.composer/vendor/bin/security-checker security:check --end-point=http://security.sensiolabs.org/check_lock
   - drupal-ti script
 

--- a/src/Entity/RunComparison.php
+++ b/src/Entity/RunComparison.php
@@ -176,6 +176,20 @@ class RunComparison extends RevisionableContentEntityBase implements RunComparis
   /**
    * {@inheritdoc}
    */
+  public function getStripType() : string {
+    return $this->get('strip_type')->getString();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStripPatterns() : array {
+    return $this->get('strip_patterns')->first()->getValue();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getRunEntities() {
     return [$this->getRun1(), $this->getRun2()];
   }
@@ -261,6 +275,16 @@ class RunComparison extends RevisionableContentEntityBase implements RunComparis
     $fields['run2'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Run 2 ID'))
       ->setDescription(t('The second run ID.'))
+      ->setRevisionable(FALSE);
+
+    $fields['strip_type'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Strip type'))
+      ->setDescription(t('Type of stripping to apply to urls/comparison keys.'))
+      ->setRevisionable(FALSE);
+
+    $fields['strip_patterns'] = BaseFieldDefinition::create('map')
+      ->setLabel(t('Strip patterns'))
+      ->setDescription(t('Patterns to strip from urls/comparison keys.'))
       ->setRevisionable(FALSE);
 
     $fields['created'] = BaseFieldDefinition::create('created')

--- a/src/Entity/RunComparisonInterface.php
+++ b/src/Entity/RunComparisonInterface.php
@@ -123,6 +123,22 @@ interface RunComparisonInterface extends RevisionableInterface, RevisionLogInter
   public function getRun2Id();
 
   /**
+   * Retrieves the url/comparison key stripping type.
+   *
+   * @return string
+   *   The url/comparison key stripping type.
+   */
+  public function getStripType();
+
+  /**
+   * Retrieves the url/comparison key stripping patterns.
+   *
+   * @return string[]
+   *   The url/comparison key stripping patterns.
+   */
+  public function getStripPatterns();
+
+  /**
    * Retrieves both run entities as an array.
    *
    * @return RunComparisonInterface[]

--- a/tests/src/Functional/RunComparisonTest.php
+++ b/tests/src/Functional/RunComparisonTest.php
@@ -80,6 +80,8 @@ class RunComparisonTest extends BrowserTestBase {
     $data = [
       'run1' => $run1->id(),
       'run2' => $run2->id(),
+      'strip_type' => '',
+      'strip_patterns' => '',
     ];
     $comparison = $this->comparisonStorage->create($data);
     $comparison->save();

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -474,3 +474,33 @@ function web_page_archive_update_8011() {
     $config_storage->write($view, $source->read($view));
   }
 }
+
+/**
+ * Add 'strip_type' and 'strip_patterns' to run comparison content type.
+ */
+function web_page_archive_update_8012() {
+  $fields['strip_type'] = BaseFieldDefinition::create('string')
+    ->setLabel(t('Strip type'))
+    ->setDescription(t('Type of stripping to apply to urls/comparison keys.'))
+    ->setRevisionable(FALSE);
+
+  $fields['strip_patterns'] = BaseFieldDefinition::create('map')
+    ->setLabel(t('Strip patterns'))
+    ->setDescription(t('Patterns to strip from urls/comparison keys.'))
+    ->setRevisionable(FALSE)
+    ->setDefaultValue([]);
+
+  foreach ($fields as $field => $storage_definition) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($field, 'wpa_run_comparison', 'wpa_run_comparison', $storage_definition);
+  }
+}
+
+/**
+ * Set default 'strip_type' and 'strip_patterns' values.
+ */
+function web_page_archive_update_8013() {
+  $query = \Drupal::database()->update('wpa_run_comparison');
+  $query->fields(['strip_type' => '', 'strip_patterns' => serialize([])]);
+  $query->execute();
+}


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2932530

This PR introduces the ability to strip strings and regular expressions from URLs during a comparison.  This allows us to treat things like https://www.website.com/some/path the same as https://staging.website.com/some/path as we can strip off any portion of the URL we want.

Updated form:
![image](https://user-images.githubusercontent.com/5263371/34798281-0e48c09c-f621-11e7-996f-2c1f0ec08f3f.png)


Example run:
![image](https://user-images.githubusercontent.com/5263371/34798011-f59ed9b0-f61f-11e7-96e3-bf94afaa6b54.png)
