### PR TITLE
fix(travis): Remove CHANGELOG.txt from standards check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ before_script:
   - drupal-ti before_script
 
 script:
-  - phpcs --standard=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme --ignore=vendor/,*.md $TRAVIS_BUILD_DIR
+  - phpcs --standard=$HOME/.composer/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme --ignore=vendor/,*.md,*.txt $TRAVIS_BUILD_DIR
   - $HOME/.composer/vendor/bin/security-checker security:check --end-point=http://security.sensiolabs.org/check_lock
   - drupal-ti script
 


### PR DESCRIPTION
This PR just fixes a minor issue with travis that marks CHANGELOG.txt and other text files as violating the coding standards. 

No need for code review here. If travis doesn't show the violations, I'll just merge as-is.