### PR TITLE
Issue #2937233 by WidgetsBurritos: Screenshot Before/After Redraw Issue

### DIFF
--- a/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -58,7 +58,7 @@ class HtmlCaptureResponse extends UriCaptureResponse {
         'class' => ['use-ajax'],
         'data-dialog-type' => 'modal',
         // TODO: Pull this value from config?
-        'data-dialog-options' => Json::encode(['width' => 1024]),
+        'data-dialog-options' => Json::encode(['width' => 1280]),
       ],
     ];
 

--- a/modules/wpa_screenshot_capture/css/wpa-slider.css
+++ b/modules/wpa_screenshot_capture/css/wpa-slider.css
@@ -1,7 +1,3 @@
-.ui-dialog-content .wpa-slider {
-  max-width: 983px;
-}
-
 .ui-dialog-content .wpa-slider .wpa-handle:after {
   position: fixed;
 }

--- a/modules/wpa_screenshot_capture/js/wpa-slider.js
+++ b/modules/wpa_screenshot_capture/js/wpa-slider.js
@@ -5,35 +5,31 @@
   Drupal.behaviors.wpaBeforeAfterSlider = {
     attach: function (context, settings) {
       var $modal = $('#drupal-modal');
-      var images = document.querySelectorAll('.image-style-web-page-archive-full');
+      var $images = $modal.find('.image-style-web-page-archive-full');
 
       // When the modal resizes, we need to ensure the images are no wider than
       // the modal itself, otherwise before/after will scale the resize
       // image differently.
       $modal.on('dialogContentResize', function() {
-        var maxWidth = $(this).width();
-        for (var i=0; i<images.length; i++) {
-          images[i].style.maxWidth = maxWidth + 'px';
-        }
+        $images.css('max-width', $(this).width() + 'px');
       })
 
       // Ensure both images load properly and then trigger before/after.
       $modal.once('wpaBeforeAfterSlider').each(function () {
         var imageLoadedCt = 0;
-        for (var i=0; i<images.length; i++) {
-          // Only trigger before/after once both images have loaded.
-          images[i].addEventListener('load', function() {
-            if (++imageLoadedCt == 2) {
-              $('.wpa-slider').beforeAfter();
-            }
-          });
 
-          // If either image fails to load for now we just open an alert.
-          // We may want to find a better solution for this in the future.
-          images[i].addEventListener('error', function() {
-            alert(Drupal.t('Could not load image.'));
-          });
-        }
+        // Only trigger before/after once both images have loaded.
+        $images.on('load', function() {
+          if (++imageLoadedCt == 2) {
+            $('.wpa-slider').beforeAfter();
+          }
+        });
+
+        // If either image fails to load for now we just open an alert.
+        // We may want to find a better solution for this in the future.
+        $images.on('error', function() {
+          alert(Drupal.t('Could not load image.'));
+        });
       });
     }
   };

--- a/modules/wpa_screenshot_capture/js/wpa-slider.js
+++ b/modules/wpa_screenshot_capture/js/wpa-slider.js
@@ -1,32 +1,40 @@
-/**
- * Initializes the WPA comparison slider.
- */
-function wpaInitializeSlider() {
-  var images = document.querySelectorAll('.image-style-web-page-archive-full');
-  var ct = 0;
+/** global: jQuery */
+/** global: Drupal */
 
-  /**
-   * Callback function when image is loaded.
-   */
-  function imageReady() {
-    if (++ct >= 2) {
-      jQuery('.ba-slider').beforeAfter();
-    }
-  }
+(function ($, Drupal) {
+  Drupal.behaviors.wpaBeforeAfterSlider = {
+    attach: function (context, settings) {
+      var $modal = $('#drupal-modal');
+      var images = document.querySelectorAll('.image-style-web-page-archive-full');
 
-  /**
-   * Loops through all the images to ensure they load properly.
-   */
-  for (i=0; i<images.length; i++) {
-    var image = images[i];
-    if (image.complete) {
-      imageReady();
-    }
-    else {
-      image.addEventListener('load', imageReady);
-      image.addEventListener('error', function() {
-        alert(Drupal.t('Could not load image.'));
+      // When the modal resizes, we need to ensure the images are no wider than
+      // the modal itself, otherwise before/after will scale the resize
+      // image differently.
+      $modal.on('dialogContentResize', function() {
+        var maxWidth = $(this).width();
+        for (var i=0; i<images.length; i++) {
+          images[i].style.maxWidth = maxWidth + 'px';
+        }
+      })
+
+      // Ensure both images load properly and then trigger before/after.
+      $modal.once('wpaBeforeAfterSlider').each(function () {
+        var imageLoadedCt = 0;
+        for (var i=0; i<images.length; i++) {
+          // Only trigger before/after once both images have loaded.
+          images[i].addEventListener('load', function() {
+            if (++imageLoadedCt == 2) {
+              $('.wpa-slider').beforeAfter();
+            }
+          });
+
+          // If either image fails to load for now we just open an alert.
+          // We may want to find a better solution for this in the future.
+          images[i].addEventListener('error', function() {
+            alert(Drupal.t('Could not load image.'));
+          });
+        }
       });
     }
-  }
-}
+  };
+})(jQuery, Drupal);

--- a/modules/wpa_screenshot_capture/templates/wpa-screenshot-compare.html.twig
+++ b/modules/wpa_screenshot_capture/templates/wpa-screenshot-compare.html.twig
@@ -18,7 +18,3 @@
   </div>
   <span class="wpa-handle handle"></span>
 </div>
-
-<script type="text/javascript">
-wpaInitializeSlider();
-</script>

--- a/modules/wpa_screenshot_capture/wpa_screenshot_capture.libraries.yml
+++ b/modules/wpa_screenshot_capture/wpa_screenshot_capture.libraries.yml
@@ -15,4 +15,5 @@ wpa-slider:
   js:
     js/wpa-slider.js: {}
   dependencies:
+    - core/jquery.once
     - wpa_screenshot_capture/before-after

--- a/modules/wpa_screenshot_capture/wpa_screenshot_capture.module
+++ b/modules/wpa_screenshot_capture/wpa_screenshot_capture.module
@@ -23,6 +23,6 @@ function wpa_screenshot_capture_theme($existing, $type, $theme, $path) {
  */
 function wpa_screenshot_capture_views_pre_render(ViewExecutable $view) {
   if (isset($view) && ($view->storage->id() == 'web_page_archive_run_comparison_summary')) {
-    $view->element['#attached']['library'][] = 'wpa_screenshot_capture/before-after';
+    $view->element['#attached']['library'][] = 'wpa_screenshot_capture/wpa-slider';
   }
 }

--- a/src/Plugin/CompareResponse/VarianceCompareResponse.php
+++ b/src/Plugin/CompareResponse/VarianceCompareResponse.php
@@ -75,7 +75,7 @@ class VarianceCompareResponse extends CompareResponseBase {
         'class' => ['use-ajax', 'button', 'button--small', 'button--primary'],
         'data-dialog-type' => 'modal',
         // TODO: Pull this value from config?
-        'data-dialog-options' => Json::encode(['width' => 1024]),
+        'data-dialog-options' => Json::encode(['width' => 1280]),
       ],
     ];
 


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/node/2937233

**Functionality changes:**
- Changed modal size from `1024` to `1280` on `HtmlCaptureResponse` and `VarianceCompareResponse` to match what we have on `ScreenshotCaptureResponse`.
- Added `core/jquery.once` as a dependency for the `wpa_screenshot_capture/wpa_slider` library.
- Rewrote `wpa-slider.js`
  - Attached functionality to `Drupal.behaviors` instead of just having a globally-accessible `wpaInitializeSlider()` function.
  - Used `jquery.once()` to trigger the functionality that starts `beforeAfter()`, once both images are loaded.
  - Listening for the `dialogContentResize` event on the modal, and then determining the modal width and setting the maxWidth on each image to the modal content width. This is where the actual bug fix comes in. The problem had to do with the width on the images getting calculated before the modal had finished sizing properly. 

**CSS changes:**
- Removed the `max-width` setting from `ui-dialog-content .wpa-slider` as this is no longer needed, per javascript changes.

**Other notes:**
- I didn't add any javascript tests for this, as just to get to a page that could use this functionality we'd have to generate a lot of entities, and it seems like a lot of fuss for little value in this particular case. But we can revisit if we thing it's necessary in the future.