### PR TITLE
Issue #2935677 by WidgetsBurritos: Add run titles to comparison run view

### DIFF
--- a/config/install/views.view.web_page_archive_run_comparison_summary.yml
+++ b/config/install/views.view.web_page_archive_run_comparison_summary.yml
@@ -554,8 +554,8 @@ display:
             value: all
             title_enable: false
             title: All
-          title_enable: false
-          title: ''
+          title_enable: true
+          title: '{{ arguments.id }}'
           default_argument_type: node
           default_argument_options: {  }
           default_argument_skip_url: false

--- a/src/Entity/RunComparisonViewsData.php
+++ b/src/Entity/RunComparisonViewsData.php
@@ -15,6 +15,9 @@ class RunComparisonViewsData extends EntityViewsData {
   public function getViewsData() {
     $data = parent::getViewsData();
 
+    // Force ID field to use custom argument.
+    $data['wpa_run_comparison']['id']['argument']['id'] = 'wpa_cid';
+
     // Setup run relationships.
     $data['wpa_run_comparison']['run1']['relationship']['id'] = 'standard';
     $data['wpa_run_comparison']['run1']['relationship']['base'] = 'web_page_archive_run_revision';

--- a/src/Plugin/views/argument/RunComparisonId.php
+++ b/src/Plugin/views/argument/RunComparisonId.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\views\argument;
+
+use Drupal\views\Plugin\views\argument\NumericArgument;
+use Drupal\web_page_archive\Entity\Sql\RunComparisonStorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Argument handler to accept a web page archive run id.
+ *
+ * @ViewsArgument("wpa_cid")
+ */
+class RunComparisonId extends NumericArgument {
+
+  /**
+   * The run comparison storage.
+   *
+   * @var \Drupal\web_page_archive_run\Entity\Sql\RunComparisonStorageInterface
+   */
+  protected $runComparisonStorage;
+
+  /**
+   * Constructs the Nid object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\web_page_archive_run\Entity\Sql\RunComparisonStorageInterface $run_comparison_storage
+   *   The run comparison storage.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RunComparisonStorageInterface $run_comparison_storage) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->runComparisonStorage = $run_comparison_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity.manager')->getStorage('wpa_run_comparison')
+    );
+  }
+
+  /**
+   * Override the behavior of title(). Get the title of the node.
+   */
+  public function titleQuery() {
+    $titles = [];
+
+    $run_comparisons = $this->runComparisonStorage->loadMultiple($this->value);
+    foreach ($run_comparisons as $run_comparison) {
+      $titles[] = $run_comparison->label();
+    }
+    return $titles;
+  }
+
+}

--- a/tests/src/Functional/RunComparisonTest.php
+++ b/tests/src/Functional/RunComparisonTest.php
@@ -78,6 +78,7 @@ class RunComparisonTest extends BrowserTestBase {
     $run2->save();
 
     $data = [
+      'name' => 'Really special comparison',
       'run1' => $run1->id(),
       'run2' => $run2->id(),
       'strip_type' => '',
@@ -118,6 +119,7 @@ class RunComparisonTest extends BrowserTestBase {
     $this->drupalLogin($this->authorizedAdminUser);
     $this->drupalGet("admin/config/system/web-page-archive/compare/{$comparison->id()}");
 
+    $assert->pageTextContains('Really special comparison');
     $assert->pageTextContains('Operator');
     $assert->pageTextContains('URL');
     $assert->pageTextContains('Exists in Run #1?');

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -570,3 +570,18 @@ function web_page_archive_update_8016() {
     $config_storage->write($view, $source->read($view));
   }
 }
+
+/**
+ * Reimports the web_page_archive_run_comparison_summary view.
+ */
+function web_page_archive_update_8017() {
+  $path = drupal_get_path('module', 'web_page_archive') . '/config/install';
+  $source = new FileStorage($path);
+  $config_storage = \Drupal::service('config.storage');
+  $views = [
+    'views.view.web_page_archive_run_comparison_summary',
+  ];
+  foreach ($views as $view) {
+    $config_storage->write($view, $source->read($view));
+  }
+}


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2935677

**Views Changes:**
- Turned on the "Override Title" option and supplied the `argument.id`.
- Wrote update hook `web_page_archive_update_8017()` which forces summary view to update.
- Mapped the `wpa_run_comparison.id` to a new `wpa_cid` argument. 

**Functionality Changes:**
- Created `wpa_cid` views argument, which is essentially just a copy/paste of `Drupal\node\Plugin\views\argument\Nid` but just for `wpa_run_comparison` entities instead.
- I updated the `RunComparisonTest` functional test, to confirm the updated title is shown on the view page.
  - I also opened a separate PR #85 that contains nothing but the test, to illustrate failure. 