### PR TITLE
Issue #2940064 by WidgetsBurritos: Introduce comparison utilities

### DIFF
--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -20,6 +20,26 @@ web_page_archive.settings:
         file_cleanup:
           type: integer
           label: 'File Cleanup'
+    comparison:
+      type: mapping
+      mapping:
+        run1:
+          type: integer
+          label: 'Run ID #1'
+        run2:
+          type: integer
+          label: 'Run ID #2'
+        strip_type:
+          type: string
+          label: 'Strip Type'
+        strip_patterns:
+          type: string
+          label: 'Strip Patterns'
+        comparison_utilities:
+          type: sequence
+          label: 'Comparison Utilities'
+          sequence:
+            type: web_page_archive.comparison_utility_settings.[%key]
     defaults:
       type: mapping
       mapping:

--- a/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -110,7 +110,7 @@ class HtmlCaptureResponse extends UriCaptureResponse {
   /**
    * {@inheritdoc}
    */
-  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b) {
+  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b, array $capture_utilities) {
     $response_factory = \Drupal::service('web_page_archive.compare.response');
     $a_content = explode(PHP_EOL, $a->retrieveFileContents());
     $b_content = explode(PHP_EOL, $b->retrieveFileContents());

--- a/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
+++ b/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
@@ -58,3 +58,12 @@ web_page_archive.wpa_screenshot_capture.settings:
         delay:
           type: integer
           label: 'Delay'
+
+
+web_page_archive.comparison_utility_settings.wpa_screenshot_capture_file_size_compare:
+  type: string
+  label: 'File Size'
+
+web_page_archive.comparison_utility_settings.wpa_screenshot_capture_imagemagick_compare:
+  type: string
+  label: ImageMagick

--- a/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/FileSizeScreenshotVarianceCompareResponse.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/FileSizeScreenshotVarianceCompareResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\wpa_screenshot_capture\Plugin\CompareResponse;
+
+/**
+ * Screenshot variance compare response based on file size.
+ */
+class FileSizeScreenshotVarianceCompareResponse extends ScreenshotVarianceCompareResponse {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_file_size_screenshot_variance_compare_response';
+  }
+
+}

--- a/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/ImageMagickScreenshotVarianceCompareResponse.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/ImageMagickScreenshotVarianceCompareResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\wpa_screenshot_capture\Plugin\CompareResponse;
+
+/**
+ * Screenshot variance compare response based on ImageMagick.
+ */
+class ImageMagickScreenshotVarianceCompareResponse extends ScreenshotVarianceCompareResponse {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_imagemagick_screenshot_variance_compare_response';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderPreview(array $options = []) {
+    // TODO: Implement this later.
+    return ['#markup' => $this->t('[TODO: ImageMagick]')];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderFull(array $options = []) {
+    // TODO: Implement this later.
+    return ['#markup' => $this->t('[TODO: ImageMagick]')];
+  }
+
+}

--- a/modules/wpa_screenshot_capture/src/Plugin/ComparisonUtility/FileSizeComparisonUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/ComparisonUtility/FileSizeComparisonUtility.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\wpa_screenshot_capture\Plugin\ComparisonUtility;
+
+use Drupal\web_page_archive\Plugin\CaptureResponseInterface;
+use Drupal\web_page_archive\Plugin\ComparisonUtilityBase;
+use Drupal\wpa_screenshot_capture\Plugin\CompareResponse\FileSizeScreenshotVarianceCompareResponse;
+
+/**
+ * Captures screenshot of a remote uri.
+ *
+ * @ComparisonUtility(
+ *   id = "wpa_screenshot_capture_file_size_compare",
+ *   label = @Translation("Screenshot: File Size", context = "Web Page Archive"),
+ *   description = @Translation("Compares images based on file size.", context = "Web Page Archive"),
+ *   tags = {"screenshot"}
+ * )
+ */
+class FileSizeComparisonUtility extends ComparisonUtilityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function compare(CaptureResponseInterface $a, CaptureResponseInterface $b) {
+    $size1 = $a->getCaptureSize();
+    $size2 = $b->getCaptureSize();
+    $variance = 100 * abs($size2 - $size1) / $size1;
+
+    if ($variance === 0) {
+      return $this->compareResponseFactory->getSameCompareResponse();
+    }
+
+    $response = new FileSizeScreenshotVarianceCompareResponse($variance);
+    $response->setFile1Size($size1);
+    $response->setFile2Size($size2);
+    return $response;
+  }
+
+}

--- a/modules/wpa_screenshot_capture/src/Plugin/ComparisonUtility/ImageMagickComparisonUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/ComparisonUtility/ImageMagickComparisonUtility.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\wpa_screenshot_capture\Plugin\ComparisonUtility;
+
+use Drupal\web_page_archive\Plugin\CaptureResponseInterface;
+use Drupal\web_page_archive\Plugin\ComparisonUtilityBase;
+use Drupal\wpa_screenshot_capture\Plugin\CompareResponse\ImageMagickScreenshotVarianceCompareResponse;
+
+/**
+ * Captures screenshot of a remote uri.
+ *
+ * @ComparisonUtility(
+ *   id = "wpa_screenshot_capture_imagemagick_compare",
+ *   label = @Translation("Screenshot: ImageMagick", context = "Web Page Archive"),
+ *   description = @Translation("Compares images and generates diff images.", context = "Web Page Archive"),
+ *   tags = {"screenshot"}
+ * )
+ */
+class ImageMagickComparisonUtility extends ComparisonUtilityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function compare(CaptureResponseInterface $a, CaptureResponseInterface $b) {
+    // TODO: Build this in a future version.
+    return new ImageMagickScreenshotVarianceCompareResponse(0);
+  }
+
+}

--- a/src/Annotation/ComparisonUtility.php
+++ b/src/Annotation/ComparisonUtility.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\web_page_archive\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Capture utility item annotation object.
+ *
+ * @see \Drupal\web_page_archive\Plugin\ComparisonUtilityManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class ComparisonUtility extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+  /**
+   * A brief description of the comparison utility.
+   *
+   * This will be shown when adding or configuring this capture utility.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $description = '';
+
+  /**
+   * Tags used for identifying what capture type this plugin is applicable for.
+   *
+   * @var array
+   */
+  public $tags = [];
+
+}

--- a/src/Entity/RunComparison.php
+++ b/src/Entity/RunComparison.php
@@ -190,6 +190,14 @@ class RunComparison extends RevisionableContentEntityBase implements RunComparis
   /**
    * {@inheritdoc}
    */
+  public function getComparisonUtilities() : array {
+    $first = $this->get('comparison_utilities')->first();
+    return isset($first) ? $first->getValue() : [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getRunEntities() {
     return [$this->getRun1(), $this->getRun2()];
   }
@@ -285,6 +293,11 @@ class RunComparison extends RevisionableContentEntityBase implements RunComparis
     $fields['strip_patterns'] = BaseFieldDefinition::create('map')
       ->setLabel(t('Strip patterns'))
       ->setDescription(t('Patterns to strip from urls/comparison keys.'))
+      ->setRevisionable(FALSE);
+
+    $fields['comparison_utilities'] = BaseFieldDefinition::create('map')
+      ->setLabel(t('Comparison utilities'))
+      ->setDescription(t('List of comparison utilities to use.'))
       ->setRevisionable(FALSE);
 
     $fields['created'] = BaseFieldDefinition::create('created')

--- a/src/Entity/RunComparisonInterface.php
+++ b/src/Entity/RunComparisonInterface.php
@@ -139,6 +139,14 @@ interface RunComparisonInterface extends RevisionableInterface, RevisionLogInter
   public function getStripPatterns();
 
   /**
+   * Retrieves list of comparison utilities.
+   *
+   * @return array
+   *   Result is hash map where the value and key are the same.
+   */
+  public function getComparisonUtilities();
+
+  /**
    * Retrieves both run entities as an array.
    *
    * @return RunComparisonInterface[]

--- a/src/Plugin/CaptureResponse/UriCaptureResponse.php
+++ b/src/Plugin/CaptureResponse/UriCaptureResponse.php
@@ -82,7 +82,7 @@ class UriCaptureResponse extends CaptureResponseBase {
   /**
    * {@inheritdoc}
    */
-  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b) {
+  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b, array $capture_utilities) {
     $response_factory = \Drupal::service('web_page_archive.compare.response');
     $a_content = explode(PHP_EOL, $a->getContent());
     $b_content = explode(PHP_EOL, $b->getContent());

--- a/src/Plugin/CaptureResponseBase.php
+++ b/src/Plugin/CaptureResponseBase.php
@@ -147,7 +147,7 @@ abstract class CaptureResponseBase implements CaptureResponseInterface {
   /**
    * Performs a comparison two responses.
    */
-  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b) {
+  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b, array $capture_utilities) {
     // We should warn if this method is not overridden. This will allow for
     // graceful handling of any existing capture responses. In next major
     // release, this should get converted to an abstract method.

--- a/src/Plugin/CompareResponse/CompareResponseCollection.php
+++ b/src/Plugin/CompareResponse/CompareResponseCollection.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\CompareResponse;
+
+use Drupal\web_page_archive\Plugin\CompareResponseBase;
+use Drupal\web_page_archive\Plugin\CompareResponseInterface;
+
+/**
+ * A compare response that is simply a collection of other responses.
+ */
+class CompareResponseCollection extends CompareResponseBase {
+
+  protected $responses;
+
+  /**
+   * Constructs a new CompareResponseCollection object.
+   */
+  public function __construct() {
+    $this->responses = [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_multiple_compare_response';
+  }
+
+  /**
+   * Adds a response to the list.
+   */
+  public function addResponse(CompareResponseInterface $compare_response, array $options = []) {
+    $this->responses[] = $compare_response;
+  }
+
+  /**
+   * Retrieves full list of responses.
+   */
+  public function getResponses() {
+    return $this->responses;
+  }
+
+  /**
+   * Renders this response.
+   */
+  public function renderable(array $options = []) {
+    $build = [];
+    $idx = 0;
+    foreach ($this->responses as $response) {
+      $build[$idx++] = $response->renderable($options);
+    }
+
+    return $build;
+  }
+
+}

--- a/src/Plugin/CompareResponseFactory.php
+++ b/src/Plugin/CompareResponseFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\web_page_archive\Plugin;
 
 use Drupal\web_page_archive\Plugin\CompareResponse\EmptyCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection;
 use Drupal\web_page_archive\Plugin\CompareResponse\NoVariantCompareResponse;
 use Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse;
 use Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse;
@@ -50,6 +51,16 @@ class CompareResponseFactory {
    */
   public function getVarianceCompareResponse($variance) {
     return new VarianceCompareResponse($variance);
+  }
+
+  /**
+   * Retrieves a multiple compare response.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   A CompareResponseCollection object.
+   */
+  public function getCompareResponseCollection() {
+    return new CompareResponseCollection();
   }
 
 }

--- a/src/Plugin/ComparisonUtilityBase.php
+++ b/src/Plugin/ComparisonUtilityBase.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Component\Plugin\PluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for image comparison utility plugins.
+ */
+abstract class ComparisonUtilityBase extends PluginBase implements ComparisonUtilityInterface, ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The capture utility ID.
+   *
+   * @var string
+   */
+  protected $uuid;
+
+  /**
+   * The weight of the capture utility.
+   *
+   * @var int|string
+   */
+  protected $weight = '';
+
+  /**
+   * The compare response factory service.
+   *
+   * @var \Drupal\web_page_archive\Plugin\CompareResponseFactory
+   */
+  protected $compareResponseFactory;
+
+  /**
+   * The configuration.
+   *
+   * @var array
+   */
+  protected $configuration;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, CompareResponseFactory $compare_response_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->setConfiguration($configuration);
+    $this->compareResponseFactory = $compare_response_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('web_page_archive.compare.response')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSummary() {
+    return [
+      '#markup' => '',
+      '#comparison_utility' => [
+        'id' => $this->pluginDefinition['id'],
+        'label' => $this->label(),
+        'description' => $this->pluginDefinition['description'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label() {
+    return $this->pluginDefinition['label'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUuid() {
+    return $this->uuid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setWeight($weight) {
+    $this->weight = $weight;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWeight() {
+    return $this->weight;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfiguration() {
+    return [
+      'uuid' => $this->getUuid(),
+      'id' => $this->getPluginId(),
+      'weight' => $this->getWeight(),
+      'data' => $this->configuration,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    $configuration += [
+      'data' => [],
+      'uuid' => '',
+      'weight' => '',
+    ];
+    $this->configuration = $configuration['data'] + $this->defaultConfiguration();
+    $this->uuid = $configuration['uuid'];
+    $this->weight = $configuration['weight'];
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isApplicable($tag) {
+    return in_array($tag, $this->getPluginDefinition()['tags']);
+  }
+
+}

--- a/src/Plugin/ComparisonUtilityInterface.php
+++ b/src/Plugin/ComparisonUtilityInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+/**
+ * Defines an interface for image comparison responses.
+ */
+interface ComparisonUtilityInterface {
+
+  /**
+   * Returns render array of the configuration of the image comparison utility.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function getSummary();
+
+  /**
+   * Returns the image comparison utility label.
+   *
+   * @return string
+   *   The image comparison utility label.
+   */
+  public function label();
+
+  /**
+   * Returns the unique ID representing the image comparison utility.
+   *
+   * @return string
+   *   The image comparison utility ID.
+   */
+  public function getUuid();
+
+  /**
+   * Returns the weight of the image comparison utility.
+   *
+   * @return int|string
+   *   Either integer weight of image comparison utility, or an empty string.
+   */
+  public function getWeight();
+
+  /**
+   * Sets the weight for this image comparison utility.
+   *
+   * @param int $weight
+   *   The weight for this image comparison utility.
+   *
+   * @return $this
+   */
+  public function setWeight($weight);
+
+  /**
+   * Indicates whether or not a tag is applicable for this comparison utility.
+   *
+   * @return bool
+   *   A boolean value indicating if the utility is applicable for the tag.
+   */
+  public function isApplicable($tag);
+
+  /**
+   * Performs a comparison between two capture responses.
+   *
+   * @return \Drupal\web_page_archive\Plugin\CompareResponseInterface
+   *   The results of a comparison.
+   */
+  public function compare(CaptureResponseInterface $a, CaptureResponseInterface $b);
+
+}

--- a/src/Plugin/ComparisonUtilityManager.php
+++ b/src/Plugin/ComparisonUtilityManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Provides the image comparison utility plugin manager.
+ */
+class ComparisonUtilityManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new ComparisonUtilityManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/ComparisonUtility', $namespaces, $module_handler, 'Drupal\web_page_archive\Plugin\ComparisonUtilityInterface', 'Drupal\web_page_archive\Annotation\ComparisonUtility');
+
+    $this->alterInfo('web_page_archive_comparison_utility_info');
+    $this->setCacheBackend($cache_backend, 'web_page_archive_comparison_utility_plugins');
+  }
+
+}

--- a/src/Plugin/QueueWorker/CompareQueueWorker.php
+++ b/src/Plugin/QueueWorker/CompareQueueWorker.php
@@ -44,11 +44,14 @@ class CompareQueueWorker extends QueueWorkerBase {
     $data['delta1'] = isset($data['runs'][$data['left_id']]) ? array_keys($data['runs'][$data['left_id']])[0] : 0;
     $data['delta2'] = isset($data['runs'][$data['right_id']]) ? array_keys($data['runs'][$data['right_id']])[0] : 0;
 
+    // Initialize comparison utilities array if it doesn't exist.
+    $comparison_utilities = $data['run_comparison']->getComparisonUtilities();
+
     // If has both left and right, we need to perform a comparison.
     if ($data['has_left'] && $data['has_right']) {
       $left_response = reset($data['runs'][$data['left_id']])['capture_response'];
       $right_response = reset($data['runs'][$data['right_id']])['capture_response'];
-      $response = call_user_func([$data['compare_class'], 'compare'], $left_response, $right_response);
+      $response = call_user_func([$data['compare_class'], 'compare'], $left_response, $right_response, $comparison_utilities);
     }
     elseif ($data['has_left']) {
       $response = $response_factory->getNoVariantCompareResponse()->markLeft();

--- a/tests/src/Functional/WebPageArchiveSettingsTest.php
+++ b/tests/src/Functional/WebPageArchiveSettingsTest.php
@@ -51,6 +51,7 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
   public function testSettingsExistAndHaveDefaultValues() {
     $assert = $this->assertSession();
     $this->drupalLogin($this->authorizedAdminUser);
+    $strip_patterns = implode(PHP_EOL, ['www.', 'staging.']);
 
     // Ensure settings link is exposed in UI.
     $this->drupalGet('admin/config/system/web-page-archive');
@@ -69,6 +70,12 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('defaults[user_agent]', 'WPA');
     $this->assertFieldByName('defaults[use_cron]', 1);
     $this->assertFieldByName('defaults[use_robots]', 1);
+    $this->assertFieldByName('comparison[run1]', '');
+    $this->assertFieldByName('comparison[run2]', '');
+    $this->assertFieldByName('comparison[strip_type]', '');
+    $this->assertFieldByName('comparison[strip_patterns]', '');
+    $this->assertNoFieldChecked('comparison[comparison_utilities][wpa_screenshot_capture_file_size_compare]');
+    $this->assertNoFieldChecked('comparison[comparison_utilities][wpa_screenshot_capture_imagemagick_compare]');
 
     // Attempt to set defaults.
     $this->drupalPostForm(
@@ -84,6 +91,12 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
         'defaults[url_type]' => 'sitemap',
         'defaults[user_agent]' => 'NinjaBot',
         'defaults[use_robots]' => 0,
+        'comparison[run1]' => 1,
+        'comparison[run2]' => 1,
+        'comparison[strip_type]' => 'string',
+        'comparison[strip_patterns]' => $strip_patterns,
+        'comparison[comparison_utilities][wpa_screenshot_capture_file_size_compare]' => 'wpa_screenshot_capture_file_size_compare',
+        'comparison[comparison_utilities][wpa_screenshot_capture_imagemagick_compare]' => 'wpa_screenshot_capture_imagemagick_compare',
       ],
       t('Save configuration')
     );
@@ -99,6 +112,12 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('defaults[url_type]', 'sitemap');
     $this->assertFieldByName('defaults[user_agent]', 'NinjaBot');
     $this->assertFieldByName('defaults[use_robots]', 0);
+    $this->assertFieldByName('comparison[run1]', '1');
+    $this->assertFieldByName('comparison[run2]', '1');
+    $this->assertFieldByName('comparison[strip_type]', 'string');
+    $this->assertFieldByName('comparison[strip_patterns]', $strip_patterns);
+    $this->assertFieldChecked('comparison[comparison_utilities][wpa_screenshot_capture_file_size_compare]');
+    $this->assertFieldChecked('comparison[comparison_utilities][wpa_screenshot_capture_imagemagick_compare]');
 
     // Ensure default values made it into the add form.
     $this->drupalGet('admin/config/system/web-page-archive/add');
@@ -108,6 +127,15 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('url_type', 'sitemap');
     $this->assertFieldByName('user_agent', 'NinjaBot');
     $this->assertFieldByName('use_robots', 0);
+
+    // Ensure default values made it into the compare form.
+    $this->drupalGet('admin/config/system/web-page-archive/compare');
+    $this->assertFieldByName('run1', '1');
+    $this->assertFieldByName('run2', '1');
+    $this->assertFieldByName('strip_type', 'string');
+    $this->assertFieldByName('strip_patterns', $strip_patterns);
+    $this->assertFieldChecked('comparison_utilities[wpa_screenshot_capture_file_size_compare]');
+    $this->assertFieldChecked('comparison_utilities[wpa_screenshot_capture_imagemagick_compare]');
   }
 
   /**

--- a/tests/src/Kernel/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
+++ b/tests/src/Kernel/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
@@ -30,46 +30,47 @@ class HtmlCaptureResponseTest extends EntityKernelTestBase {
     $file2 = __DIR__ . '/../../fixtures/sample2.html';
     $file3 = __DIR__ . '/../../fixtures/sample3.html';
     $file4 = __DIR__ . '/../../fixtures/sample4.html';
+    $compare_utilities = [];
 
     // Assert same file returns SameCompareResponse object.
     $capture1 = new HtmlCaptureResponse($file1, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file1, 'http://staging.realultimatepower.net/');
-    $response = HtmlCaptureResponse::compare($capture1, $capture2);
+    $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse', get_class($response));
     $this->assertEquals(0, $response->getVariance());
 
     // Assert changing 1/10 lines has a 10% variance.
     $capture1 = new HtmlCaptureResponse($file2, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file3, 'http://staging.realultimatepower.net/');
-    $response = HtmlCaptureResponse::compare($capture1, $capture2);
+    $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(10, $response->getVariance());
 
     // Assert going from 10 to 9 lines has 10% variance.
     $capture1 = new HtmlCaptureResponse($file2, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file1, 'http://staging.realultimatepower.net/');
-    $response = HtmlCaptureResponse::compare($capture1, $capture2);
+    $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(10, $response->getVariance());
 
     // Assert going from 9 to 10 lines has 10% variance.
     $capture1 = new HtmlCaptureResponse($file1, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file2, 'http://staging.realultimatepower.net/');
-    $response = HtmlCaptureResponse::compare($capture1, $capture2);
+    $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(10, $response->getVariance());
 
     // Assert completely different files have 100% variance.
     $capture1 = new HtmlCaptureResponse($file1, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file4, 'http://staging.realultimatepower.net/');
-    $response = HtmlCaptureResponse::compare($capture1, $capture2);
+    $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(100, $response->getVariance());
 
     // Assert completely different files have 100% variance in reverse order.
     $capture1 = new HtmlCaptureResponse($file4, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file1, 'http://staging.realultimatepower.net/');
-    $response = HtmlCaptureResponse::compare($capture1, $capture2);
+    $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(100, $response->getVariance());
   }

--- a/tests/src/Kernel/Plugin/CaptureResponse/ScreenshotCaptureResponseTest.php
+++ b/tests/src/Kernel/Plugin/CaptureResponse/ScreenshotCaptureResponseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Plugin\CaptureResponse;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\wpa_screenshot_capture\Plugin\CaptureResponse\ScreenshotCaptureResponse;
+
+/**
+ * Tests the functionality of the screenshot capture response.
+ *
+ * @group web_page_archive
+ */
+class ScreenshotCaptureResponseTest extends EntityKernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'web_page_archive',
+    'wpa_screenshot_capture',
+  ];
+
+  /**
+   * Tests ScreenshotCaptureResponse::compare().
+   */
+  public function testCompare() {
+    $file1 = __DIR__ . '/../../fixtures/drupal-org-1.png';
+    $file2 = __DIR__ . '/../../fixtures/drupal-org-2.png';
+
+    $compare_utilities = [
+      'wpa_screenshot_capture_file_size_compare' => 'wpa_screenshot_capture_file_size_compare',
+    ];
+
+    // Assert screenshots have 0.6% file size variance.
+    $capture1 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new ScreenshotCaptureResponse($file2, 'http://www.drupal.org/');
+    $response = ScreenshotCaptureResponse::compare($capture1, $capture2, $compare_utilities);
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection', get_class($response));
+    $this->assertEquals('Drupal\wpa_screenshot_capture\Plugin\CompareResponse\FileSizeScreenshotVarianceCompareResponse', get_class($response->getResponses()[0]));
+    $this->assertEquals(0.6, $response->getResponses()[0]->getVariance());
+  }
+
+}

--- a/tests/src/Kernel/Plugin/CaptureResponse/UriCaptureResponseTest.php
+++ b/tests/src/Kernel/Plugin/CaptureResponse/UriCaptureResponseTest.php
@@ -29,39 +29,40 @@ class UriCaptureResponseTest extends EntityKernelTestBase {
     $str2 = 'Are you ready to get pumped?' . PHP_EOL . 'Click "Yes" if yes.';
     $str3 = 'Are you ready to get pumped?' . PHP_EOL . 'Click "Yes" if yes. Click "No" if you\'re a little baby.';
     $str4 = 'This is something completely different';
+    $compare_utilities = [];
 
     // Assert same string returns SameCompareResponse object.
     $capture1 = new UriCaptureResponse($str1, 'http://www.realultimatepower.net/');
     $capture2 = new UriCaptureResponse($str1, 'http://staging.realultimatepower.net/');
-    $response = UriCaptureResponse::compare($capture1, $capture2);
+    $response = UriCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse', get_class($response));
     $this->assertEquals(0, $response->getVariance());
 
     // Assert changing one of two lines has a 50% variance.
     $capture1 = new UriCaptureResponse($str2, 'http://www.realultimatepower.net/');
     $capture2 = new UriCaptureResponse($str3, 'http://staging.realultimatepower.net/');
-    $response = UriCaptureResponse::compare($capture1, $capture2);
+    $response = UriCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(50, $response->getVariance());
 
     // Assert removing a line from two lines has a 50% variance.
     $capture1 = new UriCaptureResponse($str2, 'http://www.realultimatepower.net/');
     $capture2 = new UriCaptureResponse($str1, 'http://staging.realultimatepower.net/');
-    $response = UriCaptureResponse::compare($capture1, $capture2);
+    $response = UriCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(50, $response->getVariance());
 
     // Assert adding a line to a single line has a 50% variance.
     $capture1 = new UriCaptureResponse($str1, 'http://www.realultimatepower.net/');
     $capture2 = new UriCaptureResponse($str2, 'http://staging.realultimatepower.net/');
-    $response = UriCaptureResponse::compare($capture1, $capture2);
+    $response = UriCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(50, $response->getVariance());
 
     // Assert completely different strings have 100% variance.
     $capture1 = new UriCaptureResponse($str1, 'http://www.realultimatepower.net/');
     $capture2 = new UriCaptureResponse($str4, 'http://staging.realultimatepower.net/');
-    $response = UriCaptureResponse::compare($capture1, $capture2);
+    $response = UriCaptureResponse::compare($capture1, $capture2, $compare_utilities);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
     $this->assertEquals(100, $response->getVariance());
   }

--- a/tests/src/Kernel/Plugin/CompareResponse/CompareResponseCollectionTest.php
+++ b/tests/src/Kernel/Plugin/CompareResponse/CompareResponseCollectionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Plugin\CompareResponse;
+
+use Drupal\Component\Diff\Diff;
+use Drupal\Tests\web_page_archive\Kernel\EntityStorageTestBase;
+use Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection;
+use Drupal\web_page_archive\Plugin\CompareResponse\EmptyCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse;
+
+/**
+ * Tests the functionality of the html capture response.
+ *
+ * @group web_page_archive
+ */
+class CompareResponseCollectionTest extends EntityStorageTestBase {
+
+  /**
+   * Tests preview mode.
+   */
+  public function testPreviewMode() {
+    $response_collection = new CompareResponseCollection();
+    $response1 = new EmptyCompareResponse();
+    $response2 = new SameCompareResponse();
+    $response3 = new VarianceCompareResponse(33);
+    $response_collection->addResponse($response1);
+    $response_collection->addResponse($response2);
+    $response_collection->addResponse($response3);
+    $diff = new Diff(['a', 'b', 'c'], ['a', 'd', 'c']);
+    $response3->setDiff($diff);
+    $expected = [
+      ['#markup' => 'No comparison could be performed.'],
+      ['#markup' => 'Captures are identical.'],
+      [
+        '#attached' => ['library' => ['web_page_archive/admin']],
+        'link' => ['#title' => 'Display'],
+        'size1' => ['#markup' => 'Size 1: 139.09 KB'],
+        'size2' => ['#markup' => 'Size 2: 3.37 MB'],
+      ],
+    ];
+    $data = [];
+    $run_comparison = $this->container->get('entity_type.manager')->getStorage('wpa_run_comparison')->create($data);
+    $options = [
+      'index' => 0,
+      'delta1' => 3,
+      'delta2' => 5,
+      'mode' => 'preview',
+      'run_comparison' => $run_comparison,
+      'runs' => [
+        [3 => ['capture_size' => 142432]],
+        [5 => ['capture_size' => 3532235]],
+      ],
+    ];
+    $this->assertArraySubset($expected, $response_collection->renderable($options));
+  }
+
+  /**
+   * Tests full mode.
+   */
+  public function testFullMode() {
+    $response_collection = new CompareResponseCollection();
+    $response1 = new EmptyCompareResponse();
+    $response2 = new SameCompareResponse();
+    $response3 = new VarianceCompareResponse(33);
+    $diff = new Diff(['a', 'b', 'c'], ['a', 'd', 'c']);
+    $response3->setDiff($diff);
+    $response_collection->addResponse($response1);
+    $response_collection->addResponse($response2);
+    $response_collection->addResponse($response3);
+    $expected = [
+      ['#markup' => 'No comparison could be performed.'],
+      ['#markup' => 'Captures are identical.'],
+      [
+        '#attached' => [
+          'library' => ['web_page_archive/diff'],
+        ],
+        'diff' => [
+          '#type' => 'table',
+          '#attributes' => ['class' => ['wpa-diff']],
+          '#header' => [['data' => 'Run #1'], ['data' => 'Run #2']],
+          '#rows' => [
+            [
+              ['data' => '-'],
+              ['data' => ['#markup' => '<span class="diffchange">b</span>']],
+              ['data' => '+'],
+              ['data' => ['#markup' => '<span class="diffchange">d</span>']],
+            ],
+          ],
+        ],
+      ],
+    ];
+    $options = ['mode' => 'full'];
+    $this->assertArraySubset($expected, $response_collection->renderable($options));
+  }
+
+}

--- a/tests/src/Kernel/Plugin/ComparisonUtility/FileSizeComparisonUtilityTest.php
+++ b/tests/src/Kernel/Plugin/ComparisonUtility/FileSizeComparisonUtilityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Plugin\ComparisonUtility;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\wpa_screenshot_capture\Plugin\CaptureResponse\ScreenshotCaptureResponse;
+use Drupal\wpa_screenshot_capture\Plugin\ComparisonUtility\FileSizeComparisonUtility;
+
+/**
+ * Tests the functionality of the screenshot capture response.
+ *
+ * @group web_page_archive
+ */
+class FileSizeComparisonUtilityTest extends EntityKernelTestBase {
+
+  protected $fileSizeComparisonUtility;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'web_page_archive',
+    'wpa_screenshot_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $comparison_utility_manager = $this->container->get('plugin.manager.comparison_utility');
+    $this->fileSizeComparisonUtility = $comparison_utility_manager->createInstance('wpa_screenshot_capture_file_size_compare');
+  }
+
+  /**
+   * Tests ScreenshotCaptureResponse::compare().
+   */
+  public function testCompare() {
+    $file1 = __DIR__ . '/../../fixtures/drupal-org-1.png';
+    $file2 = __DIR__ . '/../../fixtures/drupal-org-2.png';
+
+    // Assert same file returns CompareResponseCollection containing
+    // SameCompareResponse object.
+    $capture1 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
+    $response = $this->fileSizeComparisonUtility->compare($capture1, $capture2);
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse', get_class($response));
+    $this->assertEquals(0, $response->getVariance());
+
+    // Assert screenshots have 0.6% file size variance.
+    $capture1 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new ScreenshotCaptureResponse($file2, 'http://www.drupal.org/');
+    $response = $this->fileSizeComparisonUtility->compare($capture1, $capture2);
+    $this->assertEquals('Drupal\wpa_screenshot_capture\Plugin\CompareResponse\FileSizeScreenshotVarianceCompareResponse', get_class($response));
+    $this->assertEquals(0.6, $response->getVariance());
+
+    // Assert screenshots have 0.6% file size variance (reversed order).
+    $capture1 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new ScreenshotCaptureResponse($file2, 'http://www.drupal.org/');
+    $response = $this->fileSizeComparisonUtility->compare($capture2, $capture1);
+    $this->assertEquals('Drupal\wpa_screenshot_capture\Plugin\CompareResponse\FileSizeScreenshotVarianceCompareResponse', get_class($response));
+    $this->assertEquals(0.6, $response->getVariance());
+  }
+
+}

--- a/tests/src/Kernel/Plugin/ComparisonUtilityManagerTest.php
+++ b/tests/src/Kernel/Plugin/ComparisonUtilityManagerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Plugin;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+
+/**
+ * Tests comparison utility management.
+ *
+ * @group web_page_archive
+ */
+class ComparisonUtilityManagerTest extends EntityKernelTestBase {
+
+  /**
+   * String translation context.
+   *
+   * @var string
+   */
+  protected $context;
+
+  /**
+   * Image comparison utility manager service.
+   *
+   * @var Drupal\web_page_archive\Plugin\ComparisonUtilityManager
+   */
+  protected $imageComparisonManager;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'web_page_archive',
+    'wpa_screenshot_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->context = ['context' => 'Web Page Archive'];
+    $this->imageComparisonManager = $this->container->get('plugin.manager.comparison_utility');
+  }
+
+  /**
+   * Tests that expected image comparison utility plugins are defined.
+   */
+  public function testImageComparisonManagerServiceExists() {
+    $expected = [
+      'wpa_screenshot_capture_imagemagick_compare' => [
+        'id' => 'wpa_screenshot_capture_imagemagick_compare',
+        'description' => new TranslatableMarkup('Compares images and generates diff images.', [], $this->context),
+        'label' => new TranslatableMarkup('Screenshot: ImageMagick', [], $this->context),
+        'class' => 'Drupal\wpa_screenshot_capture\Plugin\ComparisonUtility\ImageMagickComparisonUtility',
+        'provider' => 'wpa_screenshot_capture',
+      ],
+      'wpa_screenshot_capture_file_size_compare' => [
+        'id' => 'wpa_screenshot_capture_file_size_compare',
+        'description' => new TranslatableMarkup('Compares images based on file size.', [], $this->context),
+        'label' => new TranslatableMarkup('Screenshot: File Size', [], $this->context),
+        'class' => 'Drupal\wpa_screenshot_capture\Plugin\ComparisonUtility\FileSizeComparisonUtility',
+        'provider' => 'wpa_screenshot_capture',
+      ],
+    ];
+    $this->assertArraySubset($expected, $this->imageComparisonManager->getDefinitions());
+  }
+
+  /**
+   * Tests methods in abstract ComparisonUtilityBase class.
+   */
+  public function testComparisonUtilityBaseMethods() {
+    $instance = $this->imageComparisonManager->createInstance('wpa_screenshot_capture_imagemagick_compare');
+    $label = new TranslatableMarkup('Screenshot: ImageMagick', [], $this->context);
+    $expected_summary = [
+      '#markup' => '',
+      '#comparison_utility' => [
+        'id' => 'wpa_screenshot_capture_imagemagick_compare',
+        'description' => new TranslatableMarkup('Compares images and generates diff images.', [], $this->context),
+        'label' => $label,
+      ],
+    ];
+    $this->assertEquals($expected_summary, $instance->getSummary());
+    $this->assertEquals($label, $instance->label());
+    $instance->setWeight(50);
+    $this->assertEquals(50, $instance->getWeight());
+    $expected_configuration = [
+      'uuid' => $instance->getUuid(),
+      'id' => 'wpa_screenshot_capture_imagemagick_compare',
+      'weight' => 50,
+      'data' => [],
+    ];
+    $this->assertEquals($expected_configuration, $instance->getConfiguration());
+    $instance->setConfiguration([
+      'uuid' => 'brand new uuid',
+      'id' => 'trying_to_change_but_cant',
+      'weight' => 22,
+      'data' => ['abc', 'def'],
+    ]);
+    $expected_configuration = [
+      'uuid' => 'brand new uuid',
+      'id' => 'wpa_screenshot_capture_imagemagick_compare',
+      'weight' => 22,
+      'data' => ['abc', 'def'],
+    ];
+    $this->assertEquals($expected_configuration, $instance->getConfiguration());
+  }
+
+}

--- a/tests/src/Unit/Plugin/CompareResponse/CompareResponseCollectionTest.php
+++ b/tests/src/Unit/Plugin/CompareResponse/CompareResponseCollectionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Unit\Plugin\CompareResponse;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection;
+use Drupal\web_page_archive\Plugin\CompareResponse\EmptyCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse;
+
+/**
+ * @coversDefaultClass \Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection
+ *
+ * @group web_page_archive
+ */
+class CompareResponseCollectionTest extends UnitTestCase {
+
+  /**
+   * Tests that responses are added to the collection.
+   */
+  public function testResponsesAreAddedToCollection() {
+    $response_collection = new CompareResponseCollection();
+    $response1 = new EmptyCompareResponse();
+    $response2 = new SameCompareResponse();
+    $response_collection->addResponse($response1);
+    $response_collection->addResponse($response2);
+    $expected = [$response1, $response2];
+    $this->assertEquals($expected, $response_collection->getResponses());
+  }
+
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -585,3 +585,16 @@ function web_page_archive_update_8017() {
     $config_storage->write($view, $source->read($view));
   }
 }
+
+/**
+ * Adds comparison_utilities field to run comparison entity.
+ */
+function web_page_archive_update_8018() {
+  $storage_definition = BaseFieldDefinition::create('map')
+    ->setLabel(t('Comparison utilities'))
+    ->setDescription(t('List of comparison utilities to use.'))
+    ->setRevisionable(FALSE);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('comparison_utilities', 'wpa_run_comparison', 'wpa_run_comparison', $storage_definition);
+}

--- a/web_page_archive.services.yml
+++ b/web_page_archive.services.yml
@@ -2,6 +2,9 @@ services:
   plugin.manager.capture_utility:
     class: Drupal\web_page_archive\Plugin\CaptureUtilityManager
     parent: default_plugin_manager
+  plugin.manager.comparison_utility:
+    class: Drupal\web_page_archive\Plugin\ComparisonUtilityManager
+    parent: default_plugin_manager
   web_page_archive:
     class: Drupal\web_page_archive\ParamConverter\WebPageArchiveParamConverter
     tags:


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2940064

**Schema Changes:**
- Added definition for comparison utilities

**Functionality Changes:**
- Modified all Compare Response `compare()` methods to take the `$capture_utilities` array parameter. This contains a list of capture utilities on which to compare.
  - The `CompareQueueWorker` was modified to retrieve the applicable comparison utilities and pass them into the respective `compare()` method.
  - All relevant tests have been updated to reflect this change.
- Created new `CompareResponseCollection` class that is a CompareReponse itself, but returns an array of multiple compare responses. This is important when you use both file size and imagemagick for comparing images on a single run.  
  - For now the screenshot capture utility is the only one that uses this, but I am gonna create a separate task to convert HTML and skeleton to do the same. 
  - Kernel test has been added to explicitly test the functionality and.
  - Other tests have been modified to support the new format as well.
- Built in support for annotation-based Comparison Utility plugins.
  - These get attached to `wpa_run_comparison` entities on creation.
  - The compare form has been modified to select comparison utilities.
  - An abstract `ComparisonUtilityBase` class was created on which other plugins should extend.
  - Created `ComparisonUtilityInterface` defining basic structure.
  - Created the `ComparisonUtilityManager` for creating plugins, which was exposed as a service.
  - Plugins are tested explicitly in `ComparisonUtilityManagerTest` and `FileSizeComparisonUtilityTest`.
  - They are also tested implicitly in other tests as they change other things later in the process.
- `FileSizeComparisonUtility` and `ImageMagickComparisonUtility` were created.
  - `ScreenshotVarianceCompareResponse ` has become a base class for the `FileSizeScreenshotVarianceCompareResponse` and `ImageMagickScreenshotVarianceCompareResponse`
  - The previously default screenshot comparison functionality was moved into the `FileSizeComparisonUtility`. 
  - There is a lot of test coverage for the above. 
- The global settings form has been modified to allow you to specify default values for the run comparison form. 
  - `WebPageArchiveSettingsTest` has been updated to reflect this addition.

**Update hooks:**
- `web_page_archive_update_8018()` adds the serialized `comparison_utilities` field to the `wpa_run_comparison` content type.
  - This matches the change made in `RunComparison:: baseFieldDefinitions()`

**Followup issues:**
- Move `CompareResponseCollection` functionality into the base capture response class, and update the other capture utilities to reflect this change: https://www.drupal.org/project/web_page_archive/issues/2940351
- Implement ImageMagick functionality: https://www.drupal.org/project/web_page_archive/issues/2936374