### PR TITLE
2940351: Relocate CompareResponseCollection functionality to CaptureResponseBase

### DIFF
--- a/modules/wpa_html_capture/config/schema/wpa_html_capture.schema.yml
+++ b/modules/wpa_html_capture/config/schema/wpa_html_capture.schema.yml
@@ -16,3 +16,7 @@ web_page_archive.wpa_html_capture.settings:
         capture:
           type: boolean
           label: 'Capture?'
+
+web_page_archive.comparison_utility_settings.wpa_html_diff_compare:
+  type: string
+  label: 'HTML Diff'

--- a/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
+++ b/modules/wpa_html_capture/src/Plugin/CaptureResponse/HtmlCaptureResponse.php
@@ -3,7 +3,6 @@
 namespace Drupal\wpa_html_capture\Plugin\CaptureResponse;
 
 use Drupal\Core\Url;
-use Drupal\Component\Diff\Diff;
 use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\Html;
 use Drupal\web_page_archive\Plugin\CaptureResponseInterface;
@@ -110,18 +109,9 @@ class HtmlCaptureResponse extends UriCaptureResponse {
   /**
    * {@inheritdoc}
    */
-  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b, array $capture_utilities) {
-    $response_factory = \Drupal::service('web_page_archive.compare.response');
-    $a_content = explode(PHP_EOL, $a->retrieveFileContents());
-    $b_content = explode(PHP_EOL, $b->retrieveFileContents());
-    $diff = new Diff($a_content, $b_content);
-    if ($diff->isEmpty()) {
-      return $response_factory->getSameCompareResponse();
-    }
-    $variance = static::calculateDiffVariance($diff->getEdits());
-    $response = $response_factory->getVarianceCompareResponse($variance);
-    $response->setDiff($diff);
-    return $response;
+  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b, array $compare_utilities, array $tags = []) {
+    $tags[] = 'html';
+    return parent::compare($a, $b, $compare_utilities, $tags);
   }
 
 }

--- a/modules/wpa_html_capture/src/Plugin/CompareResponse/HtmlVarianceCompareResponse.php
+++ b/modules/wpa_html_capture/src/Plugin/CompareResponse/HtmlVarianceCompareResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\wpa_html_capture\Plugin\CompareResponse;
+
+use Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse;
+
+/**
+ * The response that indicates the variance threshold for a HTML response.
+ */
+class HtmlVarianceCompareResponse extends VarianceCompareResponse {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getId() {
+    return 'wpa_html_variance_compare_response';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getHumanReadableName() {
+    return $this->t('Line');
+  }
+
+}

--- a/modules/wpa_html_capture/src/Plugin/ComparisonUtility/HtmlDiffComparisonUtility.php
+++ b/modules/wpa_html_capture/src/Plugin/ComparisonUtility/HtmlDiffComparisonUtility.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\wpa_html_capture\Plugin\ComparisonUtility;
+
+use Drupal\Component\Diff\Diff;
+use Drupal\web_page_archive\Plugin\CaptureResponseInterface;
+use Drupal\web_page_archive\Plugin\ComparisonUtilityBase;
+use Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse;
+use Drupal\web_page_archive\Plugin\CompareResponse\TextDiffTrait;
+
+/**
+ * Captures screenshot of a remote uri.
+ *
+ * @ComparisonUtility(
+ *   id = "wpa_html_diff_compare",
+ *   label = @Translation("HTML: Diff", context = "Web Page Archive"),
+ *   description = @Translation("Compares HTML line-by-line.", context = "Web Page Archive"),
+ *   tags = {"html"}
+ * )
+ */
+class HtmlDiffComparisonUtility extends ComparisonUtilityBase {
+
+  use TextDiffTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function compare(CaptureResponseInterface $a, CaptureResponseInterface $b) {
+    $response_factory = \Drupal::service('web_page_archive.compare.response');
+    $a_content = explode(PHP_EOL, $a->retrieveFileContents());
+    $b_content = explode(PHP_EOL, $b->retrieveFileContents());
+    $diff = new Diff($a_content, $b_content);
+    if ($diff->isEmpty()) {
+      return $response_factory->getSameCompareResponse();
+    }
+    $variance = static::calculateDiffVariance($diff->getEdits());
+    $response = new HtmlVarianceCompareResponse($variance);
+    $response->setDiff($diff);
+    return $response;
+  }
+
+}

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureResponse/ScreenshotCaptureResponse.php
@@ -95,16 +95,9 @@ class ScreenshotCaptureResponse extends UriCaptureResponse {
   /**
    * {@inheritdoc}
    */
-  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b, array $compare_utilities) {
-    $comparison_utility_manager = \Drupal::service('plugin.manager.comparison_utility');
-    $response_factory = \Drupal::service('web_page_archive.compare.response');
-    $response_collection = $response_factory->getCompareResponseCollection();
-    foreach ($compare_utilities as $compare_utility) {
-      $instance = $comparison_utility_manager->createInstance($compare_utility);
-      $comparison_response = $instance->compare($a, $b);
-      $response_collection->addResponse($comparison_response);
-    }
-    return $response_collection;
+  public static function compare(CaptureResponseInterface $a, CaptureResponseInterface $b, array $compare_utilities, array $tags = []) {
+    $tags[] = 'screenshot';
+    return parent::compare($a, $b, $compare_utilities, $tags);
   }
 
 }

--- a/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/ImageMagickScreenshotVarianceCompareResponse.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/ImageMagickScreenshotVarianceCompareResponse.php
@@ -17,6 +17,13 @@ class ImageMagickScreenshotVarianceCompareResponse extends ScreenshotVarianceCom
   /**
    * {@inheritdoc}
    */
+  public function getHumanReadableName() {
+    return $this->t('Pixel');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function renderPreview(array $options = []) {
     // TODO: Implement this later.
     return ['#markup' => $this->t('[TODO: ImageMagick]')];

--- a/src/Entity/RunComparison.php
+++ b/src/Entity/RunComparison.php
@@ -213,6 +213,13 @@ class RunComparison extends RevisionableContentEntityBase implements RunComparis
   /**
    * {@inheritdoc}
    */
+  public function getResultAtIndex($index) {
+    return \Drupal::entityTypeManager()->getStorage('wpa_run_comparison')->getResultAtIndex($index);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getResults() {
     return \Drupal::entityTypeManager()->getStorage('wpa_run_comparison')->getResults($this);
   }

--- a/src/Entity/RunComparisonInterface.php
+++ b/src/Entity/RunComparisonInterface.php
@@ -163,6 +163,14 @@ interface RunComparisonInterface extends RevisionableInterface, RevisionLogInter
   public function getQueue();
 
   /**
+   * Retrieves a particular comparison result.
+   *
+   * @return array
+   *   An associative array containing comparison results.
+   */
+  public function getResultAtIndex($index);
+
+  /**
    * Retrieves list of comparison results.
    *
    * @return array

--- a/src/Entity/Sql/RunComparisonStorage.php
+++ b/src/Entity/Sql/RunComparisonStorage.php
@@ -111,6 +111,16 @@ class RunComparisonStorage extends SqlContentEntityStorage implements RunCompari
   /**
    * {@inheritdoc}
    */
+  public function getResultAtIndex($index) : array {
+    $query = $this->database->query(
+      'SELECT * FROM {web_page_archive_run_comparison_details} WHERE cid=:cid ORDER BY url',
+      [':cid' => $index]);
+    return $query->fetchAssoc();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getResults(RunComparisonInterface $entity) {
     $query = $this->database->query(
       'SELECT * FROM {web_page_archive_run_comparison_details} WHERE revision_id=:revision_id ORDER BY url',

--- a/src/Plugin/CompareResponse/TextDiffTrait.php
+++ b/src/Plugin/CompareResponse/TextDiffTrait.php
@@ -28,4 +28,32 @@ trait TextDiffTrait {
     return isset($this->diff) ? $this->diff : [];
   }
 
+  /**
+   * Calulates variance based on a edit array from DiffEngine.
+   */
+  public static function calculateDiffVariance(array $diff_edits) {
+    // If both strings are empty, there is 0% variance.
+    $counts = [
+      'empty' => 0,
+      'add' => 1,
+      'copy' => 0,
+      'change' => 1,
+      'delete' => 1,
+      'copy-and-change' => 1,
+      'copy-change-copy' => 1,
+      'copy-change-copy-add' => 1,
+      'copy-delete' => 1,
+    ];
+    $changes = 0;
+    $total_ct = 0;
+    foreach ($diff_edits as $diff_edit) {
+      if (isset($counts[$diff_edit->type])) {
+        $lines = max(count($diff_edit->orig), count($diff_edit->closing));
+        $changes += $counts[$diff_edit->type] * $lines;
+        $total_ct += $lines;
+      }
+    }
+    return $total_ct > 0 ? 100 * $changes / $total_ct : 0;
+  }
+
 }

--- a/src/Plugin/CompareResponse/VarianceCompareResponse.php
+++ b/src/Plugin/CompareResponse/VarianceCompareResponse.php
@@ -53,6 +53,30 @@ class VarianceCompareResponse extends CompareResponseBase {
       'index' => $options['index'],
     ];
 
+    // Retrieve variance calculations.
+    if (!empty($options['index'])) {
+      $result = $options['run_comparison']->getResultAtIndex($options['index']);
+      if ($result) {
+        $results = unserialize($result['results']);
+        if (!empty($results['compare_response'])) {
+          $variance_ct = 0;
+          foreach ($results['compare_response']->getResponses() as $response) {
+            $replacements = [
+              '@variance' => $response->getVariance(),
+              '@response_type' => $response->getHumanReadableName(),
+            ];
+            $render["variance{$variance_ct}"] = [
+              '#prefix' => '<div class="wpa-comparison-variance">',
+              '#markup' => $this->t('@response_type Variance: @variance%', $replacements),
+              '#suffix' => '</div>',
+            ];
+            $variance_ct++;
+          }
+        }
+      }
+    }
+
+    // Show file sizes.
     $ct = 0;
     foreach ($options['runs'] as $details) {
       $ct++;
@@ -103,6 +127,13 @@ class VarianceCompareResponse extends CompareResponseBase {
       ],
     ];
     return $build;
+  }
+
+  /**
+   * Returns a human-readable string for the compare response.
+   */
+  public function getHumanReadableName() {
+    return $this->t('Size');
   }
 
 }

--- a/tests/src/Kernel/Controller/RunComparisonControllerTest.php
+++ b/tests/src/Kernel/Controller/RunComparisonControllerTest.php
@@ -301,8 +301,8 @@ class RunComparisonControllerTest extends EntityStorageTestBase {
 
     $expected = [
       '1' => [
-        'run1' => $run_comparison->getRun1Id(),
-        'run2' => $run_comparison->getRun2Id(),
+        'run1' => (string) $run_comparison->getRun1Id(),
+        'run2' => (string) $run_comparison->getRun2Id(),
         'delta1' => '4',
         'delta2' => '4',
         'has_left' => '1',
@@ -312,8 +312,8 @@ class RunComparisonControllerTest extends EntityStorageTestBase {
         'variance' => '0',
       ],
       '2' => [
-        'run1' => $run_comparison->getRun1Id(),
-        'run2' => $run_comparison->getRun2Id(),
+        'run1' => (string) $run_comparison->getRun1Id(),
+        'run2' => (string) $run_comparison->getRun2Id(),
         'delta1' => '13',
         'delta2' => '0',
         'has_left' => '1',

--- a/tests/src/Kernel/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
+++ b/tests/src/Kernel/Plugin/CaptureResponse/HtmlCaptureResponseTest.php
@@ -30,49 +30,67 @@ class HtmlCaptureResponseTest extends EntityKernelTestBase {
     $file2 = __DIR__ . '/../../fixtures/sample2.html';
     $file3 = __DIR__ . '/../../fixtures/sample3.html';
     $file4 = __DIR__ . '/../../fixtures/sample4.html';
-    $compare_utilities = [];
+    $compare_utilities = ['wpa_html_diff_compare'];
 
     // Assert same file returns SameCompareResponse object.
     $capture1 = new HtmlCaptureResponse($file1, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file1, 'http://staging.realultimatepower.net/');
     $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
-    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse', get_class($response));
-    $this->assertEquals(0, $response->getVariance());
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection', get_class($response));
+    $responses = $response->getResponses();
+    $this->assertEquals(1, count($responses));
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse', get_class($responses[0]));
+    $this->assertEquals(0, $responses[0]->getVariance());
 
     // Assert changing 1/10 lines has a 10% variance.
     $capture1 = new HtmlCaptureResponse($file2, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file3, 'http://staging.realultimatepower.net/');
     $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
-    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
-    $this->assertEquals(10, $response->getVariance());
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection', get_class($response));
+    $responses = $response->getResponses();
+    $this->assertEquals(1, count($responses));
+    $this->assertEquals('Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse', get_class($responses[0]));
+    $this->assertEquals(10, $responses[0]->getVariance());
 
     // Assert going from 10 to 9 lines has 10% variance.
     $capture1 = new HtmlCaptureResponse($file2, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file1, 'http://staging.realultimatepower.net/');
     $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
-    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
-    $this->assertEquals(10, $response->getVariance());
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection', get_class($response));
+    $responses = $response->getResponses();
+    $this->assertEquals(1, count($responses));
+    $this->assertEquals('Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse', get_class($responses[0]));
+    $this->assertEquals(10, $responses[0]->getVariance());
 
     // Assert going from 9 to 10 lines has 10% variance.
     $capture1 = new HtmlCaptureResponse($file1, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file2, 'http://staging.realultimatepower.net/');
     $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
-    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
-    $this->assertEquals(10, $response->getVariance());
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection', get_class($response));
+    $responses = $response->getResponses();
+    $this->assertEquals(1, count($responses));
+    $this->assertEquals('Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse', get_class($responses[0]));
+    $this->assertEquals(10, $responses[0]->getVariance());
 
     // Assert completely different files have 100% variance.
     $capture1 = new HtmlCaptureResponse($file1, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file4, 'http://staging.realultimatepower.net/');
     $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
-    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
-    $this->assertEquals(100, $response->getVariance());
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection', get_class($response));
+    $responses = $response->getResponses();
+    $this->assertEquals(1, count($responses));
+    $this->assertEquals('Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse', get_class($responses[0]));
+    $this->assertEquals(100, $responses[0]->getVariance());
 
     // Assert completely different files have 100% variance in reverse order.
     $capture1 = new HtmlCaptureResponse($file4, 'http://www.realultimatepower.net/');
     $capture2 = new HtmlCaptureResponse($file1, 'http://staging.realultimatepower.net/');
     $response = HtmlCaptureResponse::compare($capture1, $capture2, $compare_utilities);
-    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\VarianceCompareResponse', get_class($response));
-    $this->assertEquals(100, $response->getVariance());
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection', get_class($response));
+    $responses = $response->getResponses();
+    $this->assertEquals(1, count($responses));
+    $this->assertEquals('Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse', get_class($responses[0]));
+    $this->assertEquals(100, $responses[0]->getVariance());
   }
 
 }


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2940351

This PR relocates the functionality that adds response info to collection responses from the ScreenshotCaptureResponse to the CaptureResponseBase.

This allows us to use this functionality across multiple capture responses