### PR TITLE
Issue #2998919 by WidgetsBurritos: Test failures on dev branch for Drupal 8.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
 
     # The environment to use, supported are: drupal-7, drupal-8
     - DRUPAL_TI_ENVIRONMENT="drupal-8"
-    - DRUPAL_TI_CORE_BRANCH="8.4.x"
+    - DRUPAL_TI_CORE_BRANCH="8.6.x"
 
     # The installation profile to use:
     #- DRUPAL_TI_INSTALL_PROFILE="testing"
@@ -97,7 +97,7 @@ mysql:
 
 before_install:
   - composer self-update
-  - composer global require "lionsad/drupal_ti:1.*" "drupal/coder:8.2.*" "sensiolabs/security-checker:*"
+  - composer global require "lionsad/drupal_ti:dev-master#019dc85b6de24455e11492e63364c2a9f193c84c" "drupal/coder:8.2.*" "sensiolabs/security-checker:*"
   - drupal-ti before_install
 
 install:

--- a/modules/wpa_html_capture/wpa_html_capture.install
+++ b/modules/wpa_html_capture/wpa_html_capture.install
@@ -84,7 +84,7 @@ function wpa_html_capture_update_8001(&$sandbox = NULL) {
   $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
   if ($sandbox['#finished']) {
     $message = \Drupal::service('string_translation')->formatPlural($sandbox['progress'], 'Updated 1 web page archive run', 'Updated @count web page archive runs');
-    \drupal_set_message($message, 'status');
+    \Drupal::messenger()->addStatus($message);
   }
 
 }

--- a/modules/wpa_screenshot_capture/wpa_screenshot_capture.install
+++ b/modules/wpa_screenshot_capture/wpa_screenshot_capture.install
@@ -55,13 +55,13 @@ function wpa_screenshot_capture_update_8002() {
 function wpa_screenshot_capture_update_8003() {
   if (class_exists('\\PhantomInstaller\\PhantomBinary')) {
     $phantom_path = PhantomBinary::getDir() . '/phantomjs';
-    \drupal_set_message(t('Setting phantomjs path to "@path". To use a different version goto /admin/config/system/web-page-archive/settings to change the setting.', ['@path' => $phantom_path]));
+    \Drupal::messenger()->addStatus(t('Setting phantomjs path to "@path". To use a different version goto /admin/config/system/web-page-archive/settings to change the setting.', ['@path' => $phantom_path]));
     $config = \Drupal::configFactory()->getEditable('web_page_archive.wpa_screenshot_capture.settings');
     $config->set('system.phantomjs_path', $phantom_path);
     $config->save();
   }
   else {
-    \drupal_set_message('No previously installed version of phantomjs could be found. To set this you will need to go to /admin/config/system/web-page-archive/settings in your browser.');
+    \Drupal::messenger()->addStatus('No previously installed version of phantomjs could be found. To set this you will need to go to /admin/config/system/web-page-archive/settings in your browser.');
   }
 }
 

--- a/src/Controller/RunComparisonController.php
+++ b/src/Controller/RunComparisonController.php
@@ -4,7 +4,6 @@ namespace Drupal\web_page_archive\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Component\Utility\Tags;
-use Drupal\Component\Utility\Unicode;
 use Drupal\web_page_archive\Entity\RunComparisonInterface;
 use Drupal\web_page_archive\Entity\Sql\WebPageArchiveRunStorageInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -57,7 +56,7 @@ class RunComparisonController extends ControllerBase {
 
     if ($input = $request->query->get('q')) {
       $typed_string = Tags::explode($input);
-      $typed_string = Unicode::strtolower(array_pop($typed_string));
+      $typed_string = mb_strtolower(array_pop($typed_string));
       $count = 0;
       foreach ($revisions as $revision) {
         $label = static::generateRevisionLabel($revision->vid, $revision->name, $revision->revision_created);
@@ -243,7 +242,7 @@ class RunComparisonController extends ControllerBase {
    */
   public static function batchFinished($success, $results, $operations) {
     if ($success) {
-      \drupal_set_message(\t("The comparison has been completed."));
+      \Drupal::messenger()->addStatus(\t("The comparison has been completed."));
     }
     else {
       $error_operation = reset($operations);
@@ -251,7 +250,7 @@ class RunComparisonController extends ControllerBase {
         '@operation' => $error_operation[0],
         '@args' => print_r($error_operation[0], TRUE),
       ];
-      \drupal_set_message(\t('An error occurred while processing @operation with arguments : @args', $values));
+      \Drupal::messenger()->addError(\t('An error occurred while processing @operation with arguments : @args', $values));
     }
   }
 

--- a/src/Controller/WebPageArchiveController.php
+++ b/src/Controller/WebPageArchiveController.php
@@ -121,7 +121,7 @@ class WebPageArchiveController extends ControllerBase {
    */
   public static function batchFinished($success, $results, $operations) {
     if ($success) {
-      drupal_set_message(t("The capture has been completed."));
+      \Drupal::messenger()->addStatus(t("The capture has been completed."));
     }
     else {
       $error_operation = reset($operations);
@@ -129,7 +129,7 @@ class WebPageArchiveController extends ControllerBase {
         '@operation' => $error_operation[0],
         '@args' => print_r($error_operation[0], TRUE),
       ];
-      drupal_set_message(t('An error occurred while processing @operation with arguments : @args', $values));
+      \Drupal::messenger()->addError(t('An error occurred while processing @operation with arguments : @args', $values));
     }
   }
 
@@ -141,7 +141,7 @@ class WebPageArchiveController extends ControllerBase {
       $urlObj = Url::fromUri('https://www.drupal.org/project/web_page_archive#installation');
       $urlObj->setOptions(['attributes' => ['target' => '_blank']]);
       $instructions_link = Link::fromTextAndUrl(t('installation instructions'), $urlObj)->toString();
-      \drupal_set_message(t('Missing mtdowling/cron-expression package. Web page archive must be installed via composer. See @instructions for more information.', ['@instructions' => $instructions_link]), 'error');
+      \Drupal::messenger()->addError(t('Missing mtdowling/cron-expression package. Web page archive must be installed via composer. See @instructions for more information.', ['@instructions' => $instructions_link]));
       return FALSE;
     }
     return TRUE;

--- a/src/Cron/CronRunner.php
+++ b/src/Cron/CronRunner.php
@@ -6,6 +6,7 @@ use Cron\CronExpression;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\web_page_archive\Controller\WebPageArchiveController;
 
@@ -43,6 +44,13 @@ class CronRunner {
   protected $configFactory;
 
   /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * Constructs an WebPageArchiveEditForm object.
    *
    * @param \Drupal\Core\Lock\LockBackendInterface $lock
@@ -53,12 +61,15 @@ class CronRunner {
    *   The datetime time service.
    * @param \Drupal\Core\Config\ConfigFactory $config_factory
    *   The config factory service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Thee messenger service.
    */
-  public function __construct(LockBackendInterface $lock, StateInterface $state, TimeInterface $datetime_time, ConfigFactory $config_factory) {
+  public function __construct(LockBackendInterface $lock, StateInterface $state, TimeInterface $datetime_time, ConfigFactory $config_factory, MessengerInterface $messenger) {
     $this->lock = $lock;
     $this->state = $state;
     $this->time = $datetime_time;
     $this->configFactory = $config_factory;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -124,10 +135,10 @@ class CronRunner {
 
     // Set messages.
     if ($success_ct > 0) {
-      \drupal_set_message(\t('Processed @count URLs.', ['@count' => $success_ct]), 'status');
+      $this->messenger->addStatus(\t('Processed @count URLs.', ['@count' => $success_ct]));
     }
     if ($fail_ct > 0) {
-      \drupal_set_message(\t('Failed to process @count URLs.', ['@count' => $success_ct]), 'error');
+      $this->messenger->addError(\t('Failed to process @count URLs.', ['@count' => $success_ct]));
     }
 
     $this->state->set("web_page_archive.next_run.{$id}", $config_entity->calculateNextRun());

--- a/src/Entity/WebPageArchive.php
+++ b/src/Entity/WebPageArchive.php
@@ -5,6 +5,7 @@ namespace Drupal\web_page_archive\Entity;
 use Cron\CronExpression;
 use Drupal\Core\Config\Entity\ConfigEntityBase;
 use Drupal\Core\Entity\EntityWithPluginCollectionInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Plugin\DefaultLazyPluginCollection;
 use Drupal\web_page_archive\Plugin\CaptureUtilityInterface;
 use Drupal\web_page_archive\Controller\WebPageArchiveController;
@@ -61,6 +62,8 @@ use GuzzleHttp\HandlerStack;
  * )
  */
 class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface, EntityWithPluginCollectionInterface {
+
+  use MessengerTrait;
 
   /**
    * The Web Page Archive ID.
@@ -376,7 +379,7 @@ class WebPageArchive extends ConfigEntityBase implements WebPageArchiveInterface
     }
     catch (\Exception $e) {
       // TODO: What to do here? (future task)
-      drupal_set_message($e->getMessage(), 'warning');
+      $this->messenger()->addWarning($e->getMessage());
       return FALSE;
     }
   }

--- a/src/Entity/WebPageArchiveListBuilder.php
+++ b/src/Entity/WebPageArchiveListBuilder.php
@@ -26,7 +26,7 @@ class WebPageArchiveListBuilder extends ConfigEntityListBuilder {
     if (empty($capture_utilities)) {
       $url = Url::fromRoute('system.modules_list', [], ['fragment' => 'edit-modules-web-page-archive']);
       $link = \Drupal::l($this->t('install a capture utility module'), $url);
-      \drupal_set_message($this->t('You have installed Web Page Archive, but do not have any capture utilities installed. You will need to @install before you use this module.', ['@install' => $link]), 'warning');
+      \Drupal::messenger()->addWarning($this->t('You have installed Web Page Archive, but do not have any capture utilities installed. You will need to @install before you use this module.', ['@install' => $link]));
     }
     return parent::load();
   }

--- a/src/Form/CaptureUtilityDeleteForm.php
+++ b/src/Form/CaptureUtilityDeleteForm.php
@@ -68,7 +68,7 @@ class CaptureUtilityDeleteForm extends ConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->webPageArchive->deleteCaptureUtility($this->captureUtility);
-    drupal_set_message($this->t('The capture utility %name has been deleted.', ['%name' => $this->captureUtility->label()]));
+    $this->messenger()->addStatus($this->t('The capture utility %name has been deleted.', ['%name' => $this->captureUtility->label()]));
     $form_state->setRedirectUrl($this->webPageArchive->urlInfo('edit-form'));
   }
 

--- a/src/Form/CaptureUtilityFormBase.php
+++ b/src/Form/CaptureUtilityFormBase.php
@@ -5,6 +5,7 @@ namespace Drupal\web_page_archive\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Form\SubformState;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\web_page_archive\Entity\WebPageArchiveInterface;
 use Drupal\web_page_archive\Plugin\ConfigurableCaptureUtilityInterface;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
@@ -14,6 +15,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * Provides a base form for capture utilities.
  */
 abstract class CaptureUtilityFormBase extends FormBase {
+
+  use MessengerTrait;
 
   /**
    * The web page archive.
@@ -127,7 +130,7 @@ abstract class CaptureUtilityFormBase extends FormBase {
     }
     $this->webPageArchive->save();
 
-    drupal_set_message($this->t('The capture utility was successfully applied.'));
+    $this->messenger()->addStatus($this->t('The capture utility was successfully applied.'));
     $form_state->setRedirectUrl($this->webPageArchive->urlInfo('edit-form'));
   }
 

--- a/src/Form/PrepareUninstallForm.php
+++ b/src/Form/PrepareUninstallForm.php
@@ -4,11 +4,14 @@ namespace Drupal\web_page_archive\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 
 /**
  * Removes fields and data used by web_page_archive.
  */
 class PrepareUninstallForm extends FormBase {
+
+  use MessengerTrait;
 
   /**
    * {@inheritdoc}
@@ -53,7 +56,7 @@ class PrepareUninstallForm extends FormBase {
     ];
     batch_set($batch);
 
-    drupal_set_message($this->t('web_page_archive data has been deleted.'));
+    $this->messenger()->addStatus($this->t('web_page_archive data has been deleted.'));
   }
 
 }

--- a/src/Form/RunComparisonDeleteForm.php
+++ b/src/Form/RunComparisonDeleteForm.php
@@ -4,6 +4,7 @@ namespace Drupal\web_page_archive\Form;
 
 use Drupal\Core\Entity\ContentEntityDeleteForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Url;
 
 /**
@@ -12,6 +13,8 @@ use Drupal\Core\Url;
  * @ingroup web_page_archive
  */
 class RunComparisonDeleteForm extends ContentEntityDeleteForm {
+
+  use MessengerTrait;
 
   /**
    * {@inheritdoc}
@@ -40,7 +43,7 @@ class RunComparisonDeleteForm extends ContentEntityDeleteForm {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
 
-    drupal_set_message($this->t('content @type: deleted @label.', [
+    $this->messenger()->addStatus($this->t('content @type: deleted @label.', [
       '@type' => $this->entity->bundle(),
       '@label' => $this->entity->label(),
     ]));

--- a/src/Form/WebPageArchiveAddForm.php
+++ b/src/Form/WebPageArchiveAddForm.php
@@ -17,7 +17,7 @@ class WebPageArchiveAddForm extends WebPageArchiveFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
-    drupal_set_message($this->t('Created the %label Web page archive entity.', [
+    $this->messenger()->addStatus($this->t('Created the %label Web page archive entity.', [
       '%label' => $this->entity->label(),
     ]));
   }

--- a/src/Form/WebPageArchiveDeleteForm.php
+++ b/src/Form/WebPageArchiveDeleteForm.php
@@ -4,12 +4,15 @@ namespace Drupal\web_page_archive\Form;
 
 use Drupal\Core\Entity\EntityConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Url;
 
 /**
  * Builds the form to delete Web page archive entity entities.
  */
 class WebPageArchiveDeleteForm extends EntityConfirmFormBase {
+
+  use MessengerTrait;
 
   /**
    * {@inheritdoc}
@@ -38,7 +41,7 @@ class WebPageArchiveDeleteForm extends EntityConfirmFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
 
-    drupal_set_message($this->t('content @type: deleted @label.', [
+    $this->messenger()->addStatus($this->t('content @type: deleted @label.', [
       '@type' => $this->entity->bundle(),
       '@label' => $this->entity->label(),
     ]));

--- a/src/Form/WebPageArchiveEditForm.php
+++ b/src/Form/WebPageArchiveEditForm.php
@@ -227,7 +227,7 @@ class WebPageArchiveEditForm extends WebPageArchiveFormBase {
       $capture_utility_id = $this->entity->addCaptureUtility($capture_utility);
       $this->entity->save();
       if (!empty($capture_utility_id)) {
-        drupal_set_message($this->t('The capture utility was successfully applied.'));
+        $this->messenger()->addStatus($this->t('The capture utility was successfully applied.'));
       }
     }
   }
@@ -250,7 +250,7 @@ class WebPageArchiveEditForm extends WebPageArchiveFormBase {
    */
   public function save(array $form, FormStateInterface $form_state) {
     parent::save($form, $form_state);
-    drupal_set_message($this->t('Saved the %label Web page archive entity.', [
+    $this->messenger()->addStatus($this->t('Saved the %label Web page archive entity.', [
       '%label' => $this->entity->label(),
     ]));
   }

--- a/src/Form/WebPageArchiveFormBase.php
+++ b/src/Form/WebPageArchiveFormBase.php
@@ -7,6 +7,7 @@ use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\web_page_archive\Controller\WebPageArchiveController;
 use Drupal\web_page_archive\Parser\SitemapParser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Base form for web page archive add and edit forms.
  */
 abstract class WebPageArchiveFormBase extends EntityForm {
+
+  use MessengerTrait;
 
   /**
    * The entity being used by this form.

--- a/src/Form/WebPageArchiveQueueForm.php
+++ b/src/Form/WebPageArchiveQueueForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueWorkerManagerInterface;
 use Drupal\web_page_archive\Controller\WebPageArchiveController;
@@ -17,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package Drupal\web_page_archive\Form
  */
 class WebPageArchiveQueueForm extends EntityForm {
+
+  use MessengerTrait;
 
   /**
    * Queue factory.
@@ -101,7 +104,7 @@ class WebPageArchiveQueueForm extends EntityForm {
     }
     // If there are missing dependencies, display message.
     else {
-      drupal_set_message($this->t("Capture job can't run at this time!"), 'error');
+      $this->messenger()->addError($this->t("Capture job can't run at this time!"));
       $form['help'] = [
         '#theme' => 'item_list',
         '#items' => $this->missingDependencies,

--- a/src/Form/WebPageArchiveRunRevisionDeleteForm.php
+++ b/src/Form/WebPageArchiveRunRevisionDeleteForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -16,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class WebPageArchiveRunRevisionDeleteForm extends ConfirmFormBase {
 
+  use MessengerTrait;
 
   /**
    * The Web page archive run revision.
@@ -107,7 +109,7 @@ class WebPageArchiveRunRevisionDeleteForm extends ConfirmFormBase {
     $this->WebPageArchiveRunStorage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('Web page archive run: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    drupal_set_message(t('Revision from %revision-date of Web page archive run %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
+    $this->messenger()->addStatus(t('Revision from %revision-date of Web page archive run %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.web_page_archive_run.canonical',
        ['web_page_archive_run' => $this->revision->id()]

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -482,7 +482,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->clickLink('View Details');
 
     // Parse file path.
-    if (preg_match_all('/<span class="wpa-hidden wpa-file-path">(.*\.html)<\/span>/', $this->getRawContent(), $matches)) {
+    if (preg_match_all('/<span class="wpa-hidden wpa-file-path">(.*\.html)<\/span>/', $this->getSession()->getPage()->getContent(), $matches)) {
       $file_path = $matches[1][0];
 
       // Despite attempting to capture two URLs we should only capture 1 due
@@ -500,7 +500,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->drupalGet('admin/config/system/web-page-archive/jobs/localhost/delete');
     $this->drupalPostForm(NULL, [], t('Delete'));
     $assert->pageTextContains(t('content web_page_archive: deleted localhost'));
-    $assert->pageTextContains(t('There is no Web Page Archive yet.'));
+    $assert->pageTextContains(t('There are no web page archive entities yet.'));
 
     // Simulate a cron run.
     web_page_archive_cron();

--- a/tests/src/Unit/Cron/CronRunnerTest.php
+++ b/tests/src/Unit/Cron/CronRunnerTest.php
@@ -95,6 +95,16 @@ class CronRunnerTest extends UnitTestCase {
   }
 
   /**
+   * Helper function to get a mock messenger service.
+   */
+  private function getMockMessenger() {
+    $mock_messenger = $this->getMockBuilder('\Drupal\Core\Messenger\MessengerInterface')
+      ->getMock();
+
+    return $mock_messenger;
+  }
+
+  /**
    * Helper function to get a cron runner based on default or supplied mocks.
    */
   private function getCronRunner(array $options = []) {
@@ -110,8 +120,11 @@ class CronRunnerTest extends UnitTestCase {
     if (empty($options['mock_config_factory'])) {
       $options['mock_config_factory'] = $this->getMockConfigFactory();
     }
+    if (empty($options['mock_messenger'])) {
+      $options['mock_messenger'] = $this->getMockMessenger();
+    }
 
-    return new CronRunner($options['mock_lock'], $options['mock_state'], $options['mock_time'], $options['mock_config_factory']);
+    return new CronRunner($options['mock_lock'], $options['mock_state'], $options['mock_time'], $options['mock_config_factory'], $options['mock_messenger']);
   }
 
   /**

--- a/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
+++ b/tests/src/Unit/Plugin/QueueWorker/CaptureQueueWorkerTest.php
@@ -182,22 +182,3 @@ class CaptureQueueWorkerTest extends UnitTestCase {
   }
 
 }
-
-/**
- * Since drupal_set_message() is unavailable we need to cheat to get it in.
- *
- * @todo Delete after https://www.drupal.org/node/2278383 is in.
- * @see https://api.drupal.org/api/drupal/core!modules!aggregator!tests!src!Unit!Plugin!AggregatorPluginSettingsBaseTest.php/8.2.x
- */
-namespace Drupal\web_page_archive\Plugin\QueueWorker;
-
-if (!function_exists('drupal_set_message')) {
-
-  /**
-   * Stubs out drupal_set_message.
-   */
-  function drupal_set_message($message) {
-    throw new \Exception($message);
-  }
-
-}

--- a/web_page_archive.drush.inc
+++ b/web_page_archive.drush.inc
@@ -50,10 +50,10 @@ function drush_web_page_archive_capture($config_entity = NULL) {
     drush_backend_batch_process();
   }
   elseif (is_array($ids)) {
-    drupal_set_message(dt('Could not find any config entities matching "@config_entity".', ['@config_entity' => implode('|', $ids)]), 'status');
+    \Drupal::messenger()->addStatus(dt('Could not find any config entities matching "@config_entity".', ['@config_entity' => implode('|', $ids)]));
   }
   else {
-    drupal_set_message(dt('Could not find any config entities.'), 'status');
+    \Drupal::messenger()->addStatus(dt('Could not find any config entities.'));
   }
 }
 

--- a/web_page_archive.services.yml
+++ b/web_page_archive.services.yml
@@ -23,7 +23,7 @@ services:
       - { name: validator }
   web_page_archive.cron.runner:
     class: Drupal\web_page_archive\Cron\CronRunner
-    arguments: ['@lock', '@state', '@datetime.time', '@config.factory']
+    arguments: ['@lock', '@state', '@datetime.time', '@config.factory', '@messenger']
     tags:
       - { name: cron }
   web_page_archive.compare.response:


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/web_page_archive/issues/2998919

This PR attempts to resolve test failures (and a few deprecation notices) for Drupal 8.6.x: 

**Content changes:**
- https://www.drupal.org/node/2942588 - Drupal 8.6 changed the EntityListBuilder text from "There is no Web Page Archive yet." to "There are no web page archive entities yet."

**Deprecation notices:**
- https://www.drupal.org/node/2850048 - Use mb_* functions instead of Unicode::* methods
- https://www.drupal.org/node/2774931 - drupal_get_message() and drupal_set_message() replaced by Messenger service
- https://api.drupal.org/api/drupal/core%21tests%21Drupal%21FunctionalTests%21AssertLegacyTrait.php/function/AssertLegacyTrait%3A%3AgetRawContent/8.6.x - AssertLegacyTrait::getRawContent() deprecated

**Travis changes:**
- Force drupal to use the `8.6.x` branch
- Upgrade to the latest commit for drupal_ti (this is necessary to use phpunit 6 instead of phpunit 4)