### PR TITLE
Issue #2937227 by WidgetsBurritos: Variance filter

### DIFF
--- a/config/install/views.view.web_page_archive_run_comparison_summary.yml
+++ b/config/install/views.view.web_page_archive_run_comparison_summary.yml
@@ -449,6 +449,93 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: boolean
+        plugin_id:
+          id: plugin_id
+          table: web_page_archive_comparison_variance
+          field: plugin_id
+          relationship: cid
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: plugin_id_op
+            label: 'Variance Type'
+            description: ''
+            use_operator: false
+            operator: plugin_id_op
+            identifier: plugin_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              wpa_admin: '0'
+              wpa_readonly: '0'
+            reduce: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: web_page_archive_compare_response_filter
+        variance:
+          id: variance
+          table: web_page_archive_comparison_variance
+          field: variance
+          relationship: cid
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: '0'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: variance_op
+            label: Variance
+            description: ''
+            use_operator: true
+            operator: variance_op
+            identifier: variance
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              wpa_admin: '0'
+              wpa_readonly: '0'
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: numeric
       sorts:
         cid:
           id: cid
@@ -541,6 +628,15 @@ display:
           admin_label: 'The second individual capture results'
           required: false
           plugin_id: standard
+        cid:
+          id: cid
+          table: web_page_archive_run_comparison_details
+          field: cid
+          relationship: vid
+          group_type: group
+          admin_label: 'The web page archive comparison variance details.'
+          required: false
+          plugin_id: standard
       arguments:
         id:
           id: id
@@ -583,6 +679,7 @@ display:
         operator: AND
         groups:
           1: AND
+      group_by: true
     cache_metadata:
       max-age: 0
       contexts:

--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -165,6 +165,33 @@ views.filter.web_page_archive_capture_utility_filter:
             type: views.filter.group_item.in_operator
             label: 'Group item'
 
+views.filter.web_page_archive_compare_response_filter:
+  type: views_filter
+  label: 'Web page archive compare response filter'
+  mapping:
+    operator:
+      type: string
+      label: 'Operator'
+    value:
+      type: sequence
+      label: 'Values'
+      sequence:
+        type: string
+        label: 'Value'
+    expose:
+      type: mapping
+      label: 'Expose'
+      mapping:
+        reduce:
+          type: integer
+          label: 'Reduce'
+    group_info:
+      mapping:
+        group_items:
+          sequence:
+            type: views.filter.group_item.in_operator
+            label: 'Group item'
+
 views.field.web_page_archive_serialized_capture:
   type: views_field
   label: 'Serialized Capture Results'

--- a/modules/wpa_html_capture/src/Plugin/ComparisonUtility/HtmlDiffComparisonUtility.php
+++ b/modules/wpa_html_capture/src/Plugin/ComparisonUtility/HtmlDiffComparisonUtility.php
@@ -4,7 +4,7 @@ namespace Drupal\wpa_html_capture\Plugin\ComparisonUtility;
 
 use Drupal\Component\Diff\Diff;
 use Drupal\web_page_archive\Plugin\CaptureResponseInterface;
-use Drupal\web_page_archive\Plugin\ComparisonUtilityBase;
+use Drupal\web_page_archive\Plugin\FilterableComparisonUtilityBase;
 use Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse;
 use Drupal\web_page_archive\Plugin\CompareResponse\TextDiffTrait;
 
@@ -18,7 +18,7 @@ use Drupal\web_page_archive\Plugin\CompareResponse\TextDiffTrait;
  *   tags = {"html"}
  * )
  */
-class HtmlDiffComparisonUtility extends ComparisonUtilityBase {
+class HtmlDiffComparisonUtility extends FilterableComparisonUtilityBase {
 
   use TextDiffTrait;
 
@@ -37,6 +37,15 @@ class HtmlDiffComparisonUtility extends ComparisonUtilityBase {
     $response = new HtmlVarianceCompareResponse($variance);
     $response->setDiff($diff);
     return $response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFilterCriteria() {
+    return [
+      HtmlVarianceCompareResponse::getId() => $this->label(),
+    ];
   }
 
 }

--- a/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/PixelScreenshotVarianceCompareResponse.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CompareResponse/PixelScreenshotVarianceCompareResponse.php
@@ -8,10 +8,10 @@ namespace Drupal\wpa_screenshot_capture\Plugin\CompareResponse;
 class PixelScreenshotVarianceCompareResponse extends ScreenshotVarianceCompareResponse {
 
   /**
-   * Creates a new VarianceCompareResponse object.
+   * Creates a new PixelScreenshotVarianceCompareResponse object.
    */
   public function __construct($variance, $compare_path) {
-    $this->variance = (float) $variance;
+    parent::__construct($variance);
     $this->pixelComparePath = $compare_path;
   }
 

--- a/modules/wpa_screenshot_capture/src/Plugin/ComparisonUtility/PixelComparisonUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/ComparisonUtility/PixelComparisonUtility.php
@@ -6,7 +6,7 @@ use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\File\FileSystem;
 use Drupal\web_page_archive\Plugin\CaptureResponseInterface;
 use Drupal\web_page_archive\Plugin\CompareResponseFactory;
-use Drupal\web_page_archive\Plugin\ComparisonUtilityBase;
+use Drupal\web_page_archive\Plugin\FilterableComparisonUtilityBase;
 use Drupal\wpa_screenshot_capture\Plugin\CompareResponse\PixelScreenshotVarianceCompareResponse;
 use Symfony\Component\Process\Process;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   tags = {"screenshot"}
  * )
  */
-class PixelComparisonUtility extends ComparisonUtilityBase {
+class PixelComparisonUtility extends FilterableComparisonUtilityBase {
 
   /**
    * {@inheritdoc}
@@ -96,6 +96,15 @@ class PixelComparisonUtility extends ComparisonUtilityBase {
     $process = new Process([$magick, '--version']);
     $process->run();
     return (substr($process->getOutput(), 0, 22) === 'Version: ImageMagick 7');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFilterCriteria() {
+    return [
+      PixelScreenshotVarianceCompareResponse::getId() => $this->label(),
+    ];
   }
 
 }

--- a/src/Entity/RunComparisonViewsData.php
+++ b/src/Entity/RunComparisonViewsData.php
@@ -116,6 +116,57 @@ class RunComparisonViewsData extends EntityViewsData {
       ['field' => 'langcode', 'left_field' => 'langcode'],
     ];
 
+    // Setup relationship to comparison variance table.
+    $data['web_page_archive_run_comparison_details']['cid']['relationship']['id'] = 'standard';
+    $data['web_page_archive_run_comparison_details']['cid']['relationship']['base'] = 'web_page_archive_comparison_variance';
+    $data['web_page_archive_run_comparison_details']['cid']['relationship']['base field'] = 'cid';
+    $data['web_page_archive_run_comparison_details']['cid']['relationship']['title'] = $this->t('Web Page Archive Comparison Variance Details');
+    $data['web_page_archive_run_comparison_details']['cid']['relationship']['label'] = $this->t('The web page archive comparison variance details.');
+    $data['web_page_archive_run_comparison_details']['cid']['relationship']['extra'] = [
+      ['field' => 'cid', 'left_field' => 'cid'],
+    ];
+
+    // Expose web_page_archive_comparison_variance table and fields to views.
+    $data['web_page_archive_comparison_variance'] = [];
+    $data['web_page_archive_comparison_variance']['table'] = [];
+    $data['web_page_archive_comparison_variance']['table']['group'] = t('Web page archive run comparison variance data');
+
+    $data['web_page_archive_comparison_variance']['cid'] = [
+      'title' => $this->t('Comparison ID'),
+      'help' => $this->t('The comparison ID.'),
+      'argument' => ['id' => 'numeric'],
+      'field' => ['id' => 'standard'],
+      'filter' => ['id' => 'numeric'],
+      'sort' => ['id' => 'standard'],
+    ];
+
+    $data['web_page_archive_comparison_variance']['response_index'] = [
+      'title' => $this->t('Response Index'),
+      'help' => $this->t('The response index.'),
+      'argument' => ['id' => 'numeric'],
+      'field' => ['id' => 'standard'],
+      'filter' => ['id' => 'numeric'],
+      'sort' => ['id' => 'standard'],
+    ];
+
+    $data['web_page_archive_comparison_variance']['plugin_id'] = [
+      'title' => $this->t('Plugin ID'),
+      'help' => $this->t('The compare response plugin ID.'),
+      'argument' => ['id' => 'string'],
+      'field' => ['id' => 'standard'],
+      'filter' => ['id' => 'web_page_archive_compare_response_filter'],
+      'sort' => ['id' => 'standard'],
+    ];
+
+    $data['web_page_archive_comparison_variance']['variance'] = [
+      'title' => $this->t('Variance'),
+      'help' => $this->t('Variance between two captures.'),
+      'argument' => ['id' => 'numeric'],
+      'field' => ['id' => 'standard'],
+      'filter' => ['id' => 'numeric'],
+      'sort' => ['id' => 'standard'],
+    ];
+
     return $data;
   }
 

--- a/src/Entity/Sql/RunComparisonStorageInterface.php
+++ b/src/Entity/Sql/RunComparisonStorageInterface.php
@@ -3,8 +3,6 @@
 namespace Drupal\web_page_archive\Entity\Sql;
 
 use Drupal\Core\Entity\ContentEntityStorageInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\web_page_archive\Entity\RunComparisonInterface;
 
 /**
@@ -18,53 +16,15 @@ use Drupal\web_page_archive\Entity\RunComparisonInterface;
 interface RunComparisonStorageInterface extends ContentEntityStorageInterface {
 
   /**
-   * Gets a list of Web page archive run revision IDs for a specific run.
-   *
-   * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $entity
-   *   The run comparison entity.
-   *
-   * @return int[]
-   *   Web page archive run revision IDs (in ascending order).
-   */
-  public function revisionIds(RunComparisonInterface $entity);
-
-  /**
-   * Gets a list of revision IDs having a given user as run author.
-   *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   The user entity.
-   *
-   * @return int[]
-   *   Web page archive run revision IDs (in ascending order).
-   */
-  public function userRevisionIds(AccountInterface $account);
-
-  /**
-   * Counts the number of revisions in the default language.
-   *
-   * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $entity
-   *   The run comparison entity.
-   *
-   * @return int
-   *   The number of revisions in the default language.
-   */
-  public function countDefaultLanguageRevisions(RunComparisonInterface $entity);
-
-  /**
-   * Unsets the language for all Web page archive run with the given language.
-   *
-   * @param \Drupal\Core\Language\LanguageInterface $language
-   *   The language object.
-   */
-  public function clearRevisionsLanguage(LanguageInterface $language);
-
-  /**
    * Adds a result for the specified run comparison entity.
    *
    * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $entity
    *   The run comparison entity.
    * @param mixed[] $result
    *   An array containing the result data.
+   *
+   * @return int
+   *   ID of the added result.
    */
   public function addResult(RunComparisonInterface $entity, array $result);
 
@@ -78,5 +38,24 @@ interface RunComparisonStorageInterface extends ContentEntityStorageInterface {
    *   A list of matching results.
    */
   public function getResults(RunComparisonInterface $entity);
+
+  /**
+   * Adds normalized variance data to the database.
+   *
+   * @param array $result
+   *   Result array for adding to normalized variance table.
+   */
+  public function addNormalizedVariance(array $result);
+
+  /**
+   * Retrieves normalized variance data at the specified index.
+   *
+   * @param int $index
+   *   The ID for the run comparison entity.
+   *
+   * @return mixed[]
+   *   A list of matching results.
+   */
+  public function getNormalizedVarianceAtIndex($index);
 
 }

--- a/src/Plugin/CompareResponse/FileSizeVarianceCompareResponse.php
+++ b/src/Plugin/CompareResponse/FileSizeVarianceCompareResponse.php
@@ -11,7 +11,7 @@ class FileSizeVarianceCompareResponse extends VarianceCompareResponse {
    * {@inheritdoc}
    */
   public static function getId() {
-    return 'wpa_file_size_screenshot_variance_compare_response';
+    return 'wpa_file_size_variance_compare_response';
   }
 
   /**

--- a/src/Plugin/ComparisonUtility/FileSizeComparisonUtility.php
+++ b/src/Plugin/ComparisonUtility/FileSizeComparisonUtility.php
@@ -3,7 +3,7 @@
 namespace Drupal\web_page_archive\Plugin\ComparisonUtility;
 
 use Drupal\web_page_archive\Plugin\CaptureResponseInterface;
-use Drupal\web_page_archive\Plugin\ComparisonUtilityBase;
+use Drupal\web_page_archive\Plugin\FilterableComparisonUtilityBase;
 use Drupal\web_page_archive\Plugin\CompareResponse\FileSizeVarianceCompareResponse;
 
 /**
@@ -16,7 +16,7 @@ use Drupal\web_page_archive\Plugin\CompareResponse\FileSizeVarianceCompareRespon
  *   tags = {"file"}
  * )
  */
-class FileSizeComparisonUtility extends ComparisonUtilityBase {
+class FileSizeComparisonUtility extends FilterableComparisonUtilityBase {
 
   /**
    * {@inheritdoc}
@@ -34,6 +34,15 @@ class FileSizeComparisonUtility extends ComparisonUtilityBase {
     $response->setFile1Size($size1);
     $response->setFile2Size($size2);
     return $response;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFilterCriteria() {
+    return [
+      FileSizeVarianceCompareResponse::getId() => $this->label(),
+    ];
   }
 
 }

--- a/src/Plugin/ComparisonUtilityBase.php
+++ b/src/Plugin/ComparisonUtilityBase.php
@@ -152,6 +152,13 @@ abstract class ComparisonUtilityBase extends PluginBase implements ComparisonUti
   /**
    * {@inheritdoc}
    */
+  public function isFilterable() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function isApplicable($tag) {
     return in_array($tag, $this->getPluginDefinition()['tags']);
   }

--- a/src/Plugin/ComparisonUtilityInterface.php
+++ b/src/Plugin/ComparisonUtilityInterface.php
@@ -66,6 +66,11 @@ interface ComparisonUtilityInterface {
   public function isApplicable($tag);
 
   /**
+   * Indicates whether or not a comparison utility is filterable.
+   */
+  public function isFilterable();
+
+  /**
    * Performs a comparison between two capture responses.
    *
    * @return \Drupal\web_page_archive\Plugin\CompareResponseInterface

--- a/src/Plugin/FilterableComparisonUtilityBase.php
+++ b/src/Plugin/FilterableComparisonUtilityBase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin;
+
+/**
+ * Base class for image comparison utility plugins.
+ */
+abstract class FilterableComparisonUtilityBase extends ComparisonUtilityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isFilterable() {
+    return TRUE;
+  }
+
+  /**
+   * Retrieves filter criteria.
+   */
+  abstract public function getFilterCriteria();
+
+}

--- a/src/Plugin/FilterableComparisonUtilityBase.php
+++ b/src/Plugin/FilterableComparisonUtilityBase.php
@@ -3,7 +3,7 @@
 namespace Drupal\web_page_archive\Plugin;
 
 /**
- * Base class for image comparison utility plugins.
+ * Base class for filterable comparison utility plugins.
  */
 abstract class FilterableComparisonUtilityBase extends ComparisonUtilityBase {
 

--- a/src/Plugin/views/filter/CompareResponseFilter.php
+++ b/src/Plugin/views/filter/CompareResponseFilter.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\web_page_archive\Plugin\views\filter;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\views\Plugin\views\filter\InOperator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filter showing all filterable compare responses.
+ *
+ * @ViewsFilter("web_page_archive_compare_response_filter")
+ */
+class CompareResponseFilter extends InOperator {
+
+  /**
+   * Constructs a Bundle object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $plugin_manager
+   *   The entity manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PluginManagerInterface $plugin_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->pluginManager = $plugin_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('plugin.manager.comparison_utility')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function operators() {
+    $operators = [
+      'contains' => [
+        'title' => $this->t('Equals'),
+        'short' => $this->t('equals'),
+        'method' => 'opEquals',
+        'values' => 1,
+      ],
+    ];
+
+    return $operators;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function operatorValues($values = 1) {
+    $options = [];
+    foreach ($this->operators() as $id => $info) {
+      if (isset($info['values']) && $info['values'] == $values) {
+        $options[] = $id;
+      }
+    }
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Make sure that the entity base table is in the query.
+    $this->ensureMyTable();
+
+    $field = "{$this->tableAlias}.{$this->realField}";
+
+    $info = $this->operators();
+    if (!empty($info[$this->operator]['method'])) {
+      $this->{$info[$this->operator]['method']}($field);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function opEquals($field) {
+    // TODO: Check this:
+    foreach ($this->value as $value) {
+      $this->query->addWhere($this->options['group'], $field, $value, '=');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValueOptions() {
+    if (!isset($this->valueOptions)) {
+      $options = [];
+      $plugins = $this->pluginManager->getDefinitions();
+      foreach ($plugins as $id => $plugin) {
+        $instance = $this->pluginManager->createInstance($id);
+        if ($instance->isFilterable()) {
+          $options += $instance->getFilterCriteria();
+        }
+      }
+
+      asort($options);
+      $this->valueOptions = $options;
+    }
+
+    return $this->valueOptions;
+  }
+
+}

--- a/tests/src/Functional/RunComparisonTest.php
+++ b/tests/src/Functional/RunComparisonTest.php
@@ -145,6 +145,8 @@ class RunComparisonTest extends BrowserTestBase {
     $assert->pageTextContains('Exists in Run #1?');
     $assert->pageTextContains('Exists in Run #2?');
     $assert->pageTextContains('Variance Type');
+    $assert->pageTextContains('File: Size');
+    $assert->pageTextContains('Is greater than or equal to');
     $assert->pageTextContains('Variance: 23.3%');
     $assert->pageTextNotContains('Variance: -1%');
 

--- a/tests/src/Functional/RunComparisonTest.php
+++ b/tests/src/Functional/RunComparisonTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\web_page_archive\Functional;
 
+use Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection;
+use Drupal\web_page_archive\Plugin\CompareResponse\FileSizeVarianceCompareResponse;
 use Drupal\Tests\BrowserTestBase;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -87,6 +89,9 @@ class RunComparisonTest extends BrowserTestBase {
     $comparison = $this->comparisonStorage->create($data);
     $comparison->save();
 
+    $response_collection = new CompareResponseCollection();
+    $response_collection->addResponse(new FileSizeVarianceCompareResponse(23.3));
+
     $data = [
       'delta1' => 1,
       'delta2' => 2,
@@ -98,9 +103,17 @@ class RunComparisonTest extends BrowserTestBase {
       'run2' => $run2->id(),
       'url' => 'http://www.zombo.com',
       'variance' => 23.3,
+      'compare_response' => $response_collection,
     ];
     $this->comparisonStorage->addResult($comparison, $data);
+    $this->comparisonStorage->addNormalizedVariance([
+      'cid' => $comparison->id(),
+      'response_index' => 0,
+      'plugin_id' => FileSizeVarianceCompareResponse::getId(),
+      'variance' => 23.3,
+    ]);
 
+    $response_collection = new CompareResponseCollection();
     $data = [
       'delta1' => 2,
       'delta2' => 3,
@@ -112,8 +125,15 @@ class RunComparisonTest extends BrowserTestBase {
       'run2' => $run2->id(),
       'url' => 'http://www.homestarrunner.com',
       'variance' => -1,
+      'compare_response' => $response_collection,
     ];
     $this->comparisonStorage->addResult($comparison, $data);
+    $this->comparisonStorage->addNormalizedVariance([
+      'cid' => $comparison->id(),
+      'response_index' => 1,
+      'plugin_id' => FileSizeVarianceCompareResponse::getId(),
+      'variance' => -1,
+    ]);
 
     // Login.
     $this->drupalLogin($this->authorizedAdminUser);
@@ -124,6 +144,7 @@ class RunComparisonTest extends BrowserTestBase {
     $assert->pageTextContains('URL');
     $assert->pageTextContains('Exists in Run #1?');
     $assert->pageTextContains('Exists in Run #2?');
+    $assert->pageTextContains('Variance Type');
     $assert->pageTextContains('Variance: 23.3%');
     $assert->pageTextNotContains('Variance: -1%');
 

--- a/tests/src/Kernel/EntityStorageTestBase.php
+++ b/tests/src/Kernel/EntityStorageTestBase.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\web_page_archive\Kernel;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\web_page_archive\Controller\RunComparisonController;
 use Drupal\web_page_archive\Entity\RunComparison;
+use Drupal\web_page_archive\Plugin\CompareResponseInterface;
 
 /**
  * A base class for kernel tests that can create and store entities.
@@ -44,6 +45,7 @@ abstract class EntityStorageTestBase extends EntityKernelTestBase {
     // Install schemas and config.
     $this->installSchema('web_page_archive', 'web_page_archive_capture_details');
     $this->installSchema('web_page_archive', 'web_page_archive_run_comparison_details');
+    $this->installSchema('web_page_archive', 'web_page_archive_comparison_variance');
     $this->installEntitySchema('web_page_archive_run');
     $this->installEntitySchema('wpa_run_comparison');
     $this->installConfig(['web_page_archive']);
@@ -121,7 +123,7 @@ abstract class EntityStorageTestBase extends EntityKernelTestBase {
   /**
    * Sets mock compare results.
    */
-  protected function setMockCompareResults(RunComparison $run_comparison, $has_right = FALSE) {
+  protected function setMockCompareResults(RunComparison $run_comparison, $has_right = FALSE, CompareResponseInterface $compare_response = NULL) {
     // Create initial array.
     $data = [
       'url' => 'http://www.homestarrunner.com',
@@ -133,6 +135,7 @@ abstract class EntityStorageTestBase extends EntityKernelTestBase {
       'right_id' => $has_right ? $run_comparison->getRun2Id() : NULL,
       'run_comparison' => $run_comparison,
       'variance' => 53,
+      'compare_response' => $compare_response,
     ];
     $this->runComparisonController->markCompareComplete($data);
   }

--- a/tests/src/Kernel/Plugin/CompareResponse/FileSizeVarianceCompareResponseTest.php
+++ b/tests/src/Kernel/Plugin/CompareResponse/FileSizeVarianceCompareResponseTest.php
@@ -29,7 +29,7 @@ class FileSizeVarianceCompareResponseTest extends EntityStorageTestBase {
 
     $strip_patterns = ['www.', 'staging.'];
     $run_comparison = $this->getRunComparisonEntity('Compare job', 'My run entity', 2, 'string', $strip_patterns);
-    $this->setMockCompareResults($run_comparison, TRUE);
+    $this->setMockCompareResults($run_comparison, TRUE, $response);
 
     $options = [
       'run_comparison' => $run_comparison,
@@ -56,7 +56,7 @@ class FileSizeVarianceCompareResponseTest extends EntityStorageTestBase {
 
     $strip_patterns = ['www.', 'staging.'];
     $run_comparison = $this->getRunComparisonEntity('Compare job', 'My run entity', 2, 'string', $strip_patterns);
-    $this->setMockCompareResults($run_comparison, TRUE);
+    $this->setMockCompareResults($run_comparison, TRUE, $response);
 
     $options = [
       'run_comparison' => $run_comparison,

--- a/tests/src/Kernel/Plugin/CompareResponse/PixelScreenshotVarianceCompareResponseTest.php
+++ b/tests/src/Kernel/Plugin/CompareResponse/PixelScreenshotVarianceCompareResponseTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\web_page_archive\Kernel\Plugin\CompareResponse;
 
 use Drupal\Tests\web_page_archive\Kernel\EntityStorageTestBase;
+use Drupal\web_page_archive\Plugin\CompareResponse\CompareResponseCollection;
 use Drupal\wpa_screenshot_capture\Plugin\CompareResponse\PixelScreenshotVarianceCompareResponse;
 
 /**
@@ -29,10 +30,14 @@ class PixelScreenshotVarianceCompareResponseTest extends EntityStorageTestBase {
     $empty_response = new PixelScreenshotVarianceCompareResponse(45, '');
     $invalid_response = new PixelScreenshotVarianceCompareResponse(45, '/path/to/nowhere');
     $valid_response = new PixelScreenshotVarianceCompareResponse(45, $valid_path);
+    $response_collection = new CompareResponseCollection();
+    $response_collection->addResponse($empty_response);
+    $response_collection->addResponse($invalid_response);
+    $response_collection->addResponse($valid_response);
 
     $strip_patterns = ['www.', 'staging.'];
     $run_comparison = $this->getRunComparisonEntity('Compare job', 'My run entity', 2, 'string', $strip_patterns);
-    $this->setMockCompareResults($run_comparison, TRUE);
+    $this->setMockCompareResults($run_comparison, TRUE, $response_collection);
 
     $options = [
       'run_comparison' => $run_comparison,
@@ -77,7 +82,7 @@ class PixelScreenshotVarianceCompareResponseTest extends EntityStorageTestBase {
 
     $strip_patterns = ['www.', 'staging.'];
     $run_comparison = $this->getRunComparisonEntity('Compare job', 'My run entity', 2, 'string', $strip_patterns);
-    $this->setMockCompareResults($run_comparison, TRUE);
+    $this->setMockCompareResults($run_comparison, TRUE, $response);
 
     $options = [
       'run_comparison' => $run_comparison,

--- a/tests/src/Kernel/Plugin/CompareResponse/SliderScreenshotCompareResponseTest.php
+++ b/tests/src/Kernel/Plugin/CompareResponse/SliderScreenshotCompareResponseTest.php
@@ -30,7 +30,7 @@ class SliderScreenshotCompareResponseTest extends EntityStorageTestBase {
 
     $strip_patterns = ['www.', 'staging.'];
     $run_comparison = $this->getRunComparisonEntity('Compare job', 'My run entity', 2, 'string', $strip_patterns);
-    $this->setMockCompareResults($run_comparison, TRUE);
+    $this->setMockCompareResults($run_comparison, TRUE, $response);
 
     $options = [
       'run_comparison' => $run_comparison,

--- a/tests/src/Kernel/Plugin/ComparisonUtility/FileSizeComparisonUtilityTest.php
+++ b/tests/src/Kernel/Plugin/ComparisonUtility/FileSizeComparisonUtilityTest.php
@@ -4,10 +4,9 @@ namespace Drupal\Tests\web_page_archive\Kernel\Plugin\ComparisonUtility;
 
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\wpa_screenshot_capture\Plugin\CaptureResponse\ScreenshotCaptureResponse;
-use Drupal\wpa_screenshot_capture\Plugin\ComparisonUtility\FileSizeComparisonUtility;
 
 /**
- * Tests the functionality of the screenshot capture response.
+ * Tests the functionality of the file size comparison utility.
  *
  * @group web_page_archive
  */
@@ -20,10 +19,7 @@ class FileSizeComparisonUtilityTest extends EntityKernelTestBase {
    *
    * @var array
    */
-  public static $modules = [
-    'web_page_archive',
-    'wpa_screenshot_capture',
-  ];
+  public static $modules = ['web_page_archive'];
 
   /**
    * {@inheritdoc}
@@ -50,19 +46,27 @@ class FileSizeComparisonUtilityTest extends EntityKernelTestBase {
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse', get_class($response));
     $this->assertEquals(0, $response->getVariance());
 
-    // Assert screenshots have 0.6% file size variance.
+    // Assert files have 0.6% file size variance.
     $capture1 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
     $capture2 = new ScreenshotCaptureResponse($file2, 'http://www.drupal.org/');
     $response = $this->fileSizeComparisonUtility->compare($capture1, $capture2);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\FileSizeVarianceCompareResponse', get_class($response));
     $this->assertEquals(0.6, $response->getVariance());
 
-    // Assert screenshots have 0.6% file size variance (reversed order).
+    // Assert files have 0.6% file size variance (reversed order).
     $capture1 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
     $capture2 = new ScreenshotCaptureResponse($file2, 'http://www.drupal.org/');
     $response = $this->fileSizeComparisonUtility->compare($capture2, $capture1);
     $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\FileSizeVarianceCompareResponse', get_class($response));
     $this->assertEquals(0.6, $response->getVariance());
+  }
+
+  /**
+   * Tests FileSizeComparisonUtility::getFilterCriteria().
+   */
+  public function testGetFilterCriteria() {
+    $expected = ['wpa_file_size_variance_compare_response' => 'File: Size'];
+    $this->assertEquals($expected, $this->fileSizeComparisonUtility->getFilterCriteria());
   }
 
 }

--- a/tests/src/Kernel/Plugin/ComparisonUtility/HtmlDiffComparisonUtilityTest.php
+++ b/tests/src/Kernel/Plugin/ComparisonUtility/HtmlDiffComparisonUtilityTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Plugin\ComparisonUtility;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\wpa_html_capture\Plugin\CaptureResponse\HtmlCaptureResponse;
+
+/**
+ * Tests the functionality of the html diff comparison utility.
+ *
+ * @group web_page_archive
+ */
+class HtmlDiffComparisonUtilityTest extends EntityKernelTestBase {
+
+  protected $htmlDiffComparisonUtility;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'web_page_archive',
+    'wpa_html_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $comparison_utility_manager = $this->container->get('plugin.manager.comparison_utility');
+    $this->htmlDiffComparisonUtility = $comparison_utility_manager->createInstance('wpa_html_diff_compare');
+  }
+
+  /**
+   * Tests HtmlDiffComparisonUtility::compare().
+   */
+  public function testCompare() {
+    $file1 = __DIR__ . '/../../fixtures/sample1.html';
+    $file2 = __DIR__ . '/../../fixtures/sample2.html';
+
+    // Assert same file returns CompareResponseCollection containing
+    // SameCompareResponse object.
+    $capture1 = new HtmlCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new HtmlCaptureResponse($file1, 'http://www.drupal.org/');
+    $response = $this->htmlDiffComparisonUtility->compare($capture1, $capture2);
+    $this->assertEquals('Drupal\web_page_archive\Plugin\CompareResponse\SameCompareResponse', get_class($response));
+    $this->assertEquals(0, $response->getVariance());
+
+    // Assert files have 0.6% html diff variance.
+    $capture1 = new HtmlCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new HtmlCaptureResponse($file2, 'http://www.drupal.org/');
+    $response = $this->htmlDiffComparisonUtility->compare($capture1, $capture2);
+    $this->assertEquals('Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse', get_class($response));
+    $this->assertEquals(10.0, $response->getVariance());
+
+    // Assert files have 10% html diff variance (reversed order).
+    $capture1 = new HtmlCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new HtmlCaptureResponse($file2, 'http://www.drupal.org/');
+    $response = $this->htmlDiffComparisonUtility->compare($capture2, $capture1);
+    $this->assertEquals('Drupal\wpa_html_capture\Plugin\CompareResponse\HtmlVarianceCompareResponse', get_class($response));
+    $this->assertEquals(10.0, $response->getVariance());
+  }
+
+  /**
+   * Tests HtmlDiffComparisonUtility::getFilterCriteria().
+   */
+  public function testGetFilterCriteria() {
+    $expected = ['wpa_html_variance_compare_response' => 'HTML: Diff'];
+    $this->assertEquals($expected, $this->htmlDiffComparisonUtility->getFilterCriteria());
+  }
+
+}

--- a/tests/src/Kernel/Plugin/ComparisonUtility/PixelComparisonUtilityTest.php
+++ b/tests/src/Kernel/Plugin/ComparisonUtility/PixelComparisonUtilityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Plugin\ComparisonUtility;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+
+/**
+ * Tests the functionality of the pixel comparison utility.
+ *
+ * @group web_page_archive
+ */
+class PixelComparisonUtilityTest extends EntityKernelTestBase {
+
+  protected $pixelComparisonUtility;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'web_page_archive',
+    'wpa_screenshot_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $comparison_utility_manager = $this->container->get('plugin.manager.comparison_utility');
+    $this->pixelComparisonUtility = $comparison_utility_manager->createInstance('wpa_screenshot_capture_pixel_compare');
+  }
+
+  /**
+   * Tests PixelComparisonUtility::getFilterCriteria().
+   */
+  public function testGetFilterCriteria() {
+    $expected = ['wpa_pixel_screenshot_variance_compare_response' => 'Screenshot: Pixel'];
+    $this->assertEquals($expected, $this->pixelComparisonUtility->getFilterCriteria());
+  }
+
+}

--- a/tests/src/Kernel/Plugin/ComparisonUtility/SliderComparisonUtilityTest.php
+++ b/tests/src/Kernel/Plugin/ComparisonUtility/SliderComparisonUtilityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Plugin\ComparisonUtility;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\wpa_screenshot_capture\Plugin\CaptureResponse\ScreenshotCaptureResponse;
+
+/**
+ * Tests the functionality of the slider comparison utility.
+ *
+ * @group web_page_archive
+ */
+class SliderComparisonUtilityTest extends EntityKernelTestBase {
+
+  protected $pixelComparisonUtility;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'web_page_archive',
+    'wpa_screenshot_capture',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $comparison_utility_manager = $this->container->get('plugin.manager.comparison_utility');
+    $this->sliderComparisonUtility = $comparison_utility_manager->createInstance('wpa_screenshot_capture_slider_compare');
+  }
+
+  /**
+   * Tests SliderComparisonUtility::compare().
+   */
+  public function testCompare() {
+    $file1 = __DIR__ . '/../../fixtures/drupal-org-1.png';
+    $file2 = __DIR__ . '/../../fixtures/drupal-org-2.png';
+
+    // Assert SliderScreenshotCompareResponse variance is always zero.
+    $capture1 = new ScreenshotCaptureResponse($file1, 'http://www.drupal.org/');
+    $capture2 = new ScreenshotCaptureResponse($file2, 'http://www.drupal.org/');
+    $response = $this->sliderComparisonUtility->compare($capture1, $capture2);
+    $this->assertEquals('Drupal\wpa_screenshot_capture\Plugin\CompareResponse\SliderScreenshotCompareResponse', get_class($response));
+    $this->assertEquals(0, $response->getVariance());
+  }
+
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -195,6 +195,39 @@ function web_page_archive_schema() {
       ],
     ],
   ];
+  $schema['web_page_archive_comparison_variance'] = [
+    'description' => 'Stores detailed comparison variances',
+    'fields' => [
+      'cid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {wpa_run_comparison}.id.',
+      ],
+      'response_index' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Response index.',
+      ],
+      'plugin_id' => [
+        'type' => 'varchar_ascii',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Which compare response type this is.',
+      ],
+      'variance' => [
+        'type' => 'float',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'How much variance exists between the two compare items.',
+      ],
+    ],
+    'primary key' => ['cid', 'response_index'],
+  ];
 
   return $schema;
 }
@@ -597,4 +630,46 @@ function web_page_archive_update_8018() {
 
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('comparison_utilities', 'wpa_run_comparison', 'wpa_run_comparison', $storage_definition);
+}
+
+/**
+ * Adds the web_page_archive_comparison_variance table.
+ */
+function web_page_archive_update_8201() {
+  $spec = [
+    'description' => 'Stores detailed comparison variances',
+    'fields' => [
+      'cid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Maps to {wpa_run_comparison}.id.',
+      ],
+      'response_index' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Response index.',
+      ],
+      'plugin_id' => [
+        'type' => 'varchar_ascii',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Which compare response type this is.',
+      ],
+      'variance' => [
+        'type' => 'float',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'How much variance exists between the two compare items.',
+      ],
+    ],
+    'primary key' => ['cid', 'response_index'],
+  ];
+
+  $schema = Database::getConnection()->schema();
+  $schema->createTable('web_page_archive_comparison_variance', $spec);
 }

--- a/web_page_archive.post_update.php
+++ b/web_page_archive.post_update.php
@@ -14,6 +14,9 @@ use Drupal\web_page_archive\Controller\RunComparisonController;
 function web_page_archive_post_update_2937227_normalize_compare_response_variances(&$sandbox) {
   if (!isset($sandbox['total'])) {
     $sandbox['total'] = \Drupal::entityQuery('wpa_run_comparison')->count()->execute();
+    if ($sandbox['total'] == 0) {
+      return;
+    }
     $sandbox['progress'] = 0;
   }
 
@@ -35,7 +38,7 @@ function web_page_archive_post_update_2937227_normalize_compare_response_varianc
     $sandbox['progress']++;
   }
 
-  \Drupal::messenger()->addStatus($sandbox['progress'] . ' taxonomy terms processed out of ' . $sandbox['total']);
+  \Drupal::messenger()->addStatus($sandbox['progress'] . ' run comparisons processed out of ' . $sandbox['total']);
   $sandbox['#finished'] = ($sandbox['progress'] / $sandbox['total']);
 }
 

--- a/web_page_archive.post_update.php
+++ b/web_page_archive.post_update.php
@@ -6,6 +6,46 @@
  */
 
 use Drupal\Core\Config\FileStorage;
+use Drupal\web_page_archive\Controller\RunComparisonController;
+
+/**
+ * Issue 2937227: Normalizes compare response variances to database.
+ */
+function web_page_archive_post_update_2937227_normalize_compare_response_variances(&$sandbox) {
+  if (!isset($sandbox['total'])) {
+    $sandbox['total'] = \Drupal::entityQuery('wpa_run_comparison')->count()->execute();
+    $sandbox['progress'] = 0;
+  }
+
+  // Retrieve batch of comparison IDs.
+  $limit = 25;
+  $query = \Drupal::entityQuery('wpa_run_comparison');
+  $query->range($sandbox['progress'], $limit);
+  $ids = $query->execute();
+
+  // Retrieve comparisons.
+  $comparisons = \Drupal::entityTypeManager()->getStorage('wpa_run_comparison')->loadMultiple($ids);
+  foreach ($comparisons as $comparison) {
+    $responses = $comparison->getResults();
+    foreach ($responses as $response) {
+      $unserialized = unserialize($response['results']);
+      RunComparisonController::normalizeCompareResponseData($response['cid'], $unserialized['compare_response']);
+    }
+
+    $sandbox['progress']++;
+  }
+
+  \Drupal::messenger()->addStatus($sandbox['progress'] . ' taxonomy terms processed out of ' . $sandbox['total']);
+  $sandbox['#finished'] = ($sandbox['progress'] / $sandbox['total']);
+}
+
+/**
+ * Issue 2937227: Reimports the run comparison summary view.
+ */
+function web_page_archive_post_update_2937227_reimport_run_comparison_summary_view() {
+  $views = ['views.view.web_page_archive_run_comparison_summary'];
+  _web_page_archive_reimport_views($views);
+}
 
 /**
  * Issue 2956141: Reimports the web page archive canonical view.


### PR DESCRIPTION
**Drupal.org Issue:** https://www.drupal.org/project/web_page_archive/issues/2937227

![image](https://user-images.githubusercontent.com/5263371/47831973-f44bb000-dd60-11e8-9f4a-e006b88a4774.png)

**Data Changes:**
- `web_page_archive.install` - Added the `web_page_archive_comparison_variance` table to the  which is for normalizing comparison variance data. 
- `web_page_archive.post_update.php` - Created `web_page_archive_post_update_2937227_normalize_compare_response_variances()` for normalizing existing data in batches of 25.
- `src/Controller/RunComparisonController.php` added a `normalizeCompareResponseData()` method for normalizing compare data upon marking a comparison complete. 
- `src/Entity/Sql/RunComparisonStorage.php` and `src/Entity/Sql/RunComparisonStorageInterface.php`
  - Modified `addResult()` to return ID.
  - Added `addNormalizedVariance()` method for storing normalized variance data.
  - Added `getNormalizedVarianceAtIndex()` method for retrieving normalized variance data.

**View Changes:**
- `config/install/views.view.web_page_archive_run_comparison_summary.yml` - Updated the Run Comparison Summary view to allow for filtering by Variance Type and Variance Value.
- `src/Entity/RunComparisonViewsData.php` - This had to be updated to create the mapping from `web_page_archive_run_comparison_details` to `web_page_archive_comparison_variance` tables in views.
- `src/Plugin/views/filter/CompareResponseFilter.php` - Created the `web_page_archive_compare_response_filter` views filter, which generates a dropdown list of available compare responses. 
- `web_page_archive.post_update.php` - Created `web_page_archive_post_update_2937227_reimport_run_comparison_summary_view()` post update hook to reimport the view on existing installations.

**Comparison Utility Updates:**
- `src/Plugin/ComparisonUtilityInterface.php` - Added `isFilterable()`
- `src/Plugin/ComparisonUtilityBase.php` - Added `isFilterable()` which defaults to `FALSE`
- `src/Plugin/FilterableComparisonUtilityBase.php` - Created abstract `FilterableComparisonUtilityBase` which returns true for `isFilterable()` and defines an abstract `getFilterCriteria()` method.
- `modules/wpa_html_capture/src/Plugin/ComparisonUtility/HtmlDiffComparisonUtility.php` - Now extends `FilterableComparisonUtilityBase` and exposes `HtmlVarianceCompareResponse` to `getFilterCriteria()`.
- `modules/wpa_screenshot_capture/src/Plugin/ComparisonUtility/PixelComparisonUtility.php` - Now extends `FilterableComparisonUtilityBase` and exposes `PixelScreenshotVarianceCompareResponse ` to `getFilterCriteria()`.
- `src/Plugin/ComparisonUtility/FileSizeComparisonUtility.php` - Now extends `FilterableComparisonUtilityBase` and exposes `FileSizeVarianceCompareResponse` to `getFilterCriteria()`.

**General cleanup:**
- `src/Entity/Sql/RunComparisonStorage.php` - Removed 5 unnecessary copy/pasta methods that were never used, referencing a table that doesn't even exist.
- `src/Entity/Sql/RunComparisonStorageInterface.php` - Same as previous.
- `src/Plugin/CompareResponse/FileSizeVarianceCompareResponse.php` - Changed ID from `wpa_file_size_screenshot_variance_compare_response` to `wpa_file_size_variance_compare_response` as this was missed previously.  Since these IDs haven't been used anywhere up to this point this should be completely safe. 

**Test changes:**
- `tests/src/Kernel/EntityStorageTestBase.php` 
  - updated `setUp()` to install the `web_page_archive_comparison_variance` db table.
  - updated `setMockCompareResults` to allow the ability to specify a compare response. This is used in many tests and was important for insurance normalized variances were calculated as expected. 
- `tests/src/Kernel/Plugin/CompareResponse/FileSizeVarianceCompareResponseTest.php` - Passed in responses to all `$this->setMockCompareResults()` references.
- `tests/src/Kernel/Plugin/CompareResponse/SliderScreenshotCompareResponseTest.php` - Passed in responses to all `$this->setMockCompareResults()` references. 
- `tests/src/Kernel/Plugin/CompareResponse/PixelScreenshotVarianceCompareResponseTest.php` - Passed in responses to all `$this->setMockCompareResults()` references.
- `tests/src/Kernel/Controller/RunComparisonControllerTest.php` - Updated `testMarkCompareComplete()` to pass in a response collection and confirm the normalized data was added to the database.
- `tests/src/Functional/RunComparisonTest.php` - Add in the compare response and normalized variances and confirm the response shows up in the UI 
- `tests/src/Kernel/Plugin/ComparisonUtility/FileSizeComparisonUtilityTest.php` - fixed a few incorrect comments and added coverage for `::getFilterCriteria()`
- `tests/src/Kernel/Plugin/ComparisonUtility/HtmlDiffComparisonUtilityTest.php` - Added this missing test, based on `FileSizeComparisonUtilityTest` and modified it based on expectations for that comparison utility, and test `::getFilterCriteria()`
- `tests/src/Kernel/Plugin/ComparisonUtility/PixelComparisonUtilityTest.php` - Added this missing test, based on `FileSizeComparisonUtilityTest` and modified it based on expectations for that comparison utility and test `::getFilterCriteria()`.  Note: This doesn't actually test the `::compare()` method like the other tests do as that's dependent on a working version of ImageMagick, and that seems a bit challenging to mock.
- `tests/src/Kernel/Plugin/ComparisonUtility/SliderComparisonUtilityTest.php` - Added this missing test, based on `FileSizeComparisonUtilityTest` and modified it based on expectations for that comparison utility.  This is not a _Filterable_ comparison utility so no need `::getFilterCriteria()` method to test.