### PR TITLE
Issue #2956141 by WidgetsBurritos, mikerastiello: Bulk Download

### DIFF
--- a/config/install/views.view.web_page_archive_canonical.yml
+++ b/config/install/views.view.web_page_archive_canonical.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - web_page_archive
 _core:
-  default_config_hash: 3v1lHJqrGlulKQPWXlNrYez0Ls-k4j6qsg2VdTnptOw
+  default_config_hash: 3WUyDzDPhcr5Pow9jYCWlReHfvhNF6RTJw1wVHOdKX4
 id: web_page_archive_canonical
 label: 'Web Page Archive Canonical'
 module: views
@@ -473,6 +473,55 @@ display:
           empty_zero: false
           hide_alter_empty: false
           plugin_id: custom
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: 'Download Run'
+            make_link: true
+            path: 'admin/config/system/web-page-archive/runs/{{ vid }}/download'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
         dropbutton:
           id: dropbutton
           table: views
@@ -523,10 +572,11 @@ display:
           hide_alter_empty: true
           fields:
             nothing: nothing
+            nothing_1: nothing_1
             vid: '0'
             revision_created: '0'
-            queue_ct: '0'
             capture_utilities: '0'
+            success_ct: '0'
             capture_size: '0'
           destination: true
           plugin_id: dropbutton

--- a/src/Form/DownloadRunForm.php
+++ b/src/Form/DownloadRunForm.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\web_page_archive\Form;
+
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\web_page_archive\Plugin\FileStorageTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+/**
+ * Downloads a web page archive run.
+ */
+class DownloadRunForm extends FormBase {
+
+  use FileStorageTrait;
+
+  /**
+   * Constructs a new DownloadRunForm.
+   *
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   Date formatter service.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   */
+  public function __construct(DateFormatterInterface $date_formatter, FileSystemInterface $file_system) {
+    $this->dateFormatter = $date_formatter;
+    $this->fileSystem = $file_system;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('date.formatter'),
+      $container->get('file_system')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'web_page_archive_download_run';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $web_page_archive_run_revision = NULL) {
+    $this->runRevision = $web_page_archive_run_revision;
+    $form['intro'] = [
+      '#prefix' => '<div class="download-run-intro">',
+      '#markup' => $this->t('You can download all images from the specified run as a *.zip file.'),
+      '#suffix' => '</div>',
+    ];
+
+    $form['button'] = [
+      '#prefix' => '<div class="download-run-button">',
+      '#type' => 'submit',
+      '#value' => $this->t('Download Run'),
+      '#suffix' => '</div>',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Prepare zip file.
+    $zip = new \ZipArchive();
+    $filename = $this->downloadTitle($this->runRevision);
+    $zip_file = $this->getUniqueFileName(NULL, NULL, $filename, 'tmp', 'zip');
+    $real_zip_file = $this->fileSystem->realpath($zip_file);
+    $zip->open($real_zip_file, \ZipArchive::CREATE);
+
+    // Attach all captures.
+    $captured = $this->runRevision->getCapturedArray();
+    foreach ($this->parseCapturedList($captured) as $capture) {
+      $file_name = $this->fileSystem->basename($capture['file']);
+      $real_path = $this->fileSystem->realpath($capture['file']);
+      $zip->addFile($real_path, $file_name);
+      $summary[] = [$capture['url'], $file_name];
+    }
+
+    // Generate and attach summary.
+    if ($summary_file = $this->generateSummaryFile($summary)) {
+      $zip->addFile($summary_file, 'summary.csv');
+    }
+
+    // Close zip file and send response.
+    $zip->close();
+    clearstatcache(FALSE, $zip_file);
+    $response = new BinaryFileResponse($zip_file);
+    $response->trustXSendfileTypeHeader();
+    $response->headers->set('Content-Type', 'application/zip');
+    $response->setContentDisposition(
+      ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+      $this->fileSystem->basename($zip_file)
+    );
+    $response->deleteFileAfterSend(TRUE);
+    $response->send();
+
+    return $response;
+  }
+
+  /**
+   * Parses the captured array for individual capture results.
+   */
+  private function parseCapturedList(FieldItemList $captured) {
+    foreach ($captured as $capture) {
+      $unserialized = unserialize($capture->getString());
+      if (get_class($unserialized['capture_response']) !== '__PHP_Incomplete_Class') {
+        yield [
+          'url' => $unserialized['capture_response']->getCaptureUrl(),
+          'file' => $unserialized['capture_response']->getContent(),
+        ];
+      }
+    }
+  }
+
+  /**
+   * Generates a summary file based on a summary report array.
+   */
+  private function generateSummaryFile(array $summary) {
+    $summary_file = $this->getUniqueFileName(NULL, NULL, 'summary', 'tmp', 'csv');
+    $summary_path = $this->fileSystem->realpath($summary_file);
+    $fh = fopen($summary_path, 'w');
+    fputcsv($fh, [$this->t('Url'), $this->t('File')]);
+    foreach ($summary as $row) {
+      fputcsv($fh, $row);
+    }
+    fclose($fh);
+    return $summary_path;
+  }
+
+  /**
+   * Generates the title for the download page.
+   */
+  public function downloadTitle($web_page_archive_run_revision) {
+    $label = $web_page_archive_run_revision->label();
+    $date = $this->dateFormatter->format($web_page_archive_run_revision->getRevisionCreationTime(), 'custom', 'Y-m-d H:i:s');
+    return "{$label}: {$date}";
+  }
+
+}

--- a/web_page_archive.post_update.php
+++ b/web_page_archive.post_update.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Post Update commands for web_page_archive.
+ */
+
+use Drupal\Core\Config\FileStorage;
+
+/**
+ * Issue 2956141: Reimports the web page archive canonical view.
+ */
+function web_page_archive_post_update_2956141_reimport_canonical_view() {
+  $views = ['views.view.web_page_archive_canonical'];
+  _web_page_archive_reimport_views($views);
+}
+
+/**
+ * Helper function to reimport existing views from the install directory.
+ */
+function _web_page_archive_reimport_views($views) {
+  $path = drupal_get_path('module', 'web_page_archive') . '/config/install';
+  $source = new FileStorage($path);
+  $config_storage = \Drupal::service('config.storage');
+  foreach ($views as $view) {
+    $config_storage->write($view, $source->read($view));
+  }
+}

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -129,6 +129,20 @@ entity.web_page_archive.collection.prepare_uninstall:
   requirements:
     _permission: 'administer web page archive'
 
+entity.web_page_archive.run_download:
+  path: 'admin/config/system/web-page-archive/runs/{web_page_archive_run_revision}/download'
+  defaults:
+    _form: '\Drupal\web_page_archive\Form\DownloadRunForm'
+    _title_callback: '\Drupal\web_page_archive\Form\DownloadRunForm::downloadTitle'
+  options:
+    parameters:
+      web_page_archive_run_revision:
+        type: web_page_archive_run_revision
+      delta:
+        type: integer
+  requirements:
+    _permission: 'view web page archive results'
+
 entity.web_page_archive.modal:
   path: 'admin/config/system/web-page-archive/modal/{web_page_archive_run_revision}/{delta}'
   defaults:


### PR DESCRIPTION
**Drupal.org Issue:** https://www.drupal.org/project/web_page_archive/issues/2956141

This PR provides a bulk download option for capture runs.  I don't believe any sort of batching here should be necessary as the only really long-running process should be the actual downloading of the zip file.  If it becomes problematic and we need to provide batching, we can do so at a later time. 

**Example download file:** [rackspace-com-english-2018-10-29-01-39-26-1.zip](https://github.com/WidgetsBurritos/web_page_archive/files/2545512/rackspace-com-english-2018-10-29-01-39-26-1.zip)

**Views Updates:**
- `config/install/views.view.web_page_archive_canonical.yml` - Adds a "Download Run" action to the WPA canonical view. 
- `web_page_archive.post_update.php` - Adds `web_page_archive_post_update_2956141_reimport_canonical_view()` post update method for reimporting the canonical view (Note there may be some conflicts with #91 here depending on which PR goes in first).

![image](https://user-images.githubusercontent.com/5263371/47959260-539e0000-dfad-11e8-9a0e-efb57eaa6118.png)

**Form Updates:**
- `src/Form/DownloadRunForm.php` - Created new download run form that provides a mechanism for downloading a zip file containing run contents. 
   - `::buildForm()` - Simple form containing instructions and a button for downloading.
   - `::submitForm()` - Adds all files from the run to a temporary and unique zip file, which it then downloads and deletes.
   - `::parseCapturedList()` - Generator that parses the captured array from the specified run and yields URLs and respective filenames.
   - `::generateSummaryFile()` - Creates a summary CSV mapping all URLs to their respective file names.
   - `::downloadTitle()` - Generates a title for the run based on the config entity name and the time of execution. This is used both the in the form page title and in the generated zip file name.
- `web_page_archive.routing.yml` - Added new `entity.web_page_archive.run_download` linking to the new DownloadRunForm.

![image](https://user-images.githubusercontent.com/5263371/47959262-61538580-dfad-11e8-9326-87ed8b9664ba.png)

**Test Updates:**
- `tests/src/Functional/WebPageArchiveEntityTest.php` - Updated `testCronProcessesCaptures()`:
  - Added one more URL to the capture list
  - Ensure both captureable URLs are captured (instead of the original 1)
  - Ensure both expected capture files exist (instead of the original 1)
  - Created a new scenario to actual go download the zip file. 
    - The not only checks the resulting file is a zip file, but also verifies the actual zip file contents are as  expected.
  - Ensure both capture files are deleted when a run entity is deleted (instead of the original 1)
