### PR TITLE
Issues #3011372 & 2922939 by WidgetsBurritos: Inject CSS and add Greyscale

### DIFF
--- a/modules/wpa_screenshot_capture/config/install/web_page_archive.wpa_screenshot_capture.settings.yml
+++ b/modules/wpa_screenshot_capture/config/install/web_page_archive.wpa_screenshot_capture.settings.yml
@@ -10,3 +10,4 @@ defaults:
   image_type: png
   user_agent: WPA
   width: 1280
+  css: ''

--- a/modules/wpa_screenshot_capture/config/install/web_page_archive.wpa_screenshot_capture.settings.yml
+++ b/modules/wpa_screenshot_capture/config/install/web_page_archive.wpa_screenshot_capture.settings.yml
@@ -11,3 +11,4 @@ defaults:
   user_agent: WPA
   width: 1280
   css: ''
+  greyscale: false

--- a/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
+++ b/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
@@ -23,6 +23,9 @@ web_page_archive.capture_utility.wpa_screenshot_capture:
     css:
       type: string
       label: 'CSS'
+    greyscale:
+      type: boolean
+      label: 'Greyscale'
 
 web_page_archive.wpa_screenshot_capture.settings:
   type: config_object
@@ -73,6 +76,9 @@ web_page_archive.wpa_screenshot_capture.settings:
         css:
           type: string
           label: 'CSS'
+        greyscale:
+          type: boolean
+          label: 'Greyscale'
 
 web_page_archive.comparison_utility_settings.wpa_screenshot_capture_pixel_compare:
   type: string

--- a/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
+++ b/modules/wpa_screenshot_capture/config/schema/wpa_screenshot_capture.schema.yml
@@ -20,6 +20,9 @@ web_page_archive.capture_utility.wpa_screenshot_capture:
     delay:
       type: integer
       label: 'Delay'
+    css:
+      type: string
+      label: 'CSS'
 
 web_page_archive.wpa_screenshot_capture.settings:
   type: config_object
@@ -67,6 +70,9 @@ web_page_archive.wpa_screenshot_capture.settings:
         delay:
           type: integer
           label: 'Delay'
+        css:
+          type: string
+          label: 'CSS'
 
 web_page_archive.comparison_utility_settings.wpa_screenshot_capture_pixel_compare:
   type: string

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -108,6 +108,11 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       $screenCapture->setOption('addStyleTag', json_encode(['content' => $css]));
     }
 
+    $greyscale = $this->configuration['greyscale'];
+    if ($greyscale) {
+      $screenCapture->greyscale();
+    }
+
     if (!empty($system_settings['node_modules_path'])) {
       $screenCapture->setNodeModulePath($system_settings['node_modules_path']);
     }
@@ -174,6 +179,7 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       'background_color' => $config->get('defaults.background_color'),
       'image_type' => $config->get('defaults.image_type'),
       'css' => $config->get('defaults.css'),
+      'greyscale' => $config->get('defaults.greyscale'),
     ];
   }
 
@@ -242,6 +248,17 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
         ],
       ],
     ];
+    $form['greyscale'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Capture in Greyscale?'),
+      '#description' => $this->t('If checked, images will be captured in greyscale, which can help minimize file size.'),
+      '#default_value' => $this->configuration['greyscale'],
+      '#states' => [
+        'visible' => [
+          'select[name="data[browser]"]' => ['value' => 'chrome'],
+        ],
+      ],
+    ];
 
     return $form;
   }
@@ -259,6 +276,7 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       'background_color',
       'delay',
       'css',
+      'greyscale',
     ];
 
     foreach ($fields as $field) {

--- a/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
+++ b/modules/wpa_screenshot_capture/src/Plugin/CaptureUtility/ScreenshotCaptureUtility.php
@@ -103,6 +103,11 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       ->fullPage()
       ->setOption('viewport.width', (int) $this->configuration['width']);
 
+    $css = trim($this->configuration['css']);
+    if (!empty($css)) {
+      $screenCapture->setOption('addStyleTag', json_encode(['content' => $css]));
+    }
+
     if (!empty($system_settings['node_modules_path'])) {
       $screenCapture->setNodeModulePath($system_settings['node_modules_path']);
     }
@@ -168,6 +173,7 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       'delay' => $config->get('defaults.delay'),
       'background_color' => $config->get('defaults.background_color'),
       'image_type' => $config->get('defaults.image_type'),
+      'css' => $config->get('defaults.css'),
     ];
   }
 
@@ -224,6 +230,18 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
       '#default_value' => $this->configuration['delay'],
       '#required' => TRUE,
     ];
+    $form['css'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('CSS'),
+      '#description' => $this->t('Additional CSS to apply prioring to capturing.'),
+      '#default_value' => $this->configuration['css'],
+      '#required' => FALSE,
+      '#states' => [
+        'visible' => [
+          'select[name="data[browser]"]' => ['value' => 'chrome'],
+        ],
+      ],
+    ];
 
     return $form;
   }
@@ -234,7 +252,14 @@ class ScreenshotCaptureUtility extends ConfigurableCaptureUtilityBase {
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::submitConfigurationForm($form, $form_state);
 
-    $fields = ['browser', 'width', 'image_type', 'background_color', 'delay'];
+    $fields = [
+      'browser',
+      'width',
+      'image_type',
+      'background_color',
+      'delay',
+      'css',
+    ];
 
     foreach ($fields as $field) {
       $this->configuration[$field] = $form_state->getValue($field);

--- a/modules/wpa_screenshot_capture/wpa_screenshot_capture.post_update.php
+++ b/modules/wpa_screenshot_capture/wpa_screenshot_capture.post_update.php
@@ -9,6 +9,20 @@
  * Issue 3011372: Sets CSS value to empty string for existing config entities.
  */
 function wpa_screenshot_capture_post_update_3011372_set_default_css_value() {
+  _wpa_screenshot_capture_update_data_fields(['css' => '']);
+}
+
+/**
+ * Issue 2922939: Sets greyscale value to false for existing config entities.
+ */
+function wpa_screenshot_capture_post_update_2922939_set_default_greyscale_value() {
+  _wpa_screenshot_capture_update_data_fields(['greyscale' => FALSE]);
+}
+
+/**
+ * Helper function for updating the data array values in screenshot entities.
+ */
+function _wpa_screenshot_capture_update_data_fields(array $data = []) {
   $config_factory = \Drupal::configFactory();
   $config_prefix = 'web_page_archive.web_page_archive';
   $keys = $config_factory->listAll($config_prefix);
@@ -22,8 +36,12 @@ function wpa_screenshot_capture_post_update_3011372_set_default_css_value() {
     // Search for screenshot capture utilities, remove clip_width and set delay.
     foreach ($utilities as $key => $utility) {
       if ($utilities[$key]['id'] == 'wpa_screenshot_capture') {
-        $utilities[$key]['data']['css'] = '';
-        $changed = TRUE;
+        if (!empty($data)) {
+          foreach ($data as $data_key => $data_value) {
+            $utilities[$key]['data'][$data_key] = $data_value;
+          }
+          $changed = TRUE;
+        }
       }
     }
 

--- a/modules/wpa_screenshot_capture/wpa_screenshot_capture.post_update.php
+++ b/modules/wpa_screenshot_capture/wpa_screenshot_capture.post_update.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Post Update commands for wpa_screenshot_capture module.
+ */
+
+/**
+ * Issue 3011372: Sets CSS value to empty string for existing config entities.
+ */
+function wpa_screenshot_capture_post_update_3011372_set_default_css_value() {
+  $config_factory = \Drupal::configFactory();
+  $config_prefix = 'web_page_archive.web_page_archive';
+  $keys = $config_factory->listAll($config_prefix);
+
+  foreach ($keys as $key) {
+    $wpa_config = $config_factory->getEditable($key);
+
+    $utilities = $wpa_config->get('capture_utilities');
+    $changed = FALSE;
+
+    // Search for screenshot capture utilities, remove clip_width and set delay.
+    foreach ($utilities as $key => $utility) {
+      if ($utilities[$key]['id'] == 'wpa_screenshot_capture') {
+        $utilities[$key]['data']['css'] = '';
+        $changed = TRUE;
+      }
+    }
+
+    // Update config entity if changed.
+    if ($changed) {
+      $wpa_config->set('capture_utilities', $utilities);
+      $wpa_config->save();
+    }
+  }
+}

--- a/tests/src/Functional/WebPageArchiveConfigTest.php
+++ b/tests/src/Functional/WebPageArchiveConfigTest.php
@@ -124,6 +124,7 @@ class WebPageArchiveConfigTest extends BrowserTestBase {
     $this->assertFieldByName('data[image_type]', 'jpg');
     $this->assertFieldByName('data[delay]', 1000);
     $this->assertFieldByName('data[css]', 'body { font-size: 30px; }');
+    $this->assertFieldChecked('data[greyscale]');
   }
 
 }

--- a/tests/src/Functional/WebPageArchiveConfigTest.php
+++ b/tests/src/Functional/WebPageArchiveConfigTest.php
@@ -123,6 +123,7 @@ class WebPageArchiveConfigTest extends BrowserTestBase {
     $this->assertFieldByName('data[width]', 1500);
     $this->assertFieldByName('data[image_type]', 'jpg');
     $this->assertFieldByName('data[delay]', 1000);
+    $this->assertFieldByName('data[css]', 'body { font-size: 30px; }');
   }
 
 }

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -120,6 +120,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('data[width]', '1280');
     $this->assertFieldByName('data[image_type]', 'png');
     $this->assertFieldByName('data[delay]', '0');
+    $this->assertFieldByName('data[css]', '');
 
     // Alter a few values and then submit.
     $this->drupalPostForm(
@@ -128,6 +129,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
         'data[width]' => '1400',
         'data[image_type]' => 'jpg',
         'data[delay]' => '250',
+        'data[css]' => 'body { font-weight: 900; }',
       ],
       t('Add capture utility')
     );
@@ -140,6 +142,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('data[width]', '1400');
     $this->assertFieldByName('data[image_type]', 'jpg');
     $this->assertFieldByName('data[delay]', '250');
+    $this->assertFieldByName('data[css]', 'body { font-weight: 900; }');
 
     // Attempt to image type.
     $this->drupalPostForm(

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -121,6 +121,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('data[image_type]', 'png');
     $this->assertFieldByName('data[delay]', '0');
     $this->assertFieldByName('data[css]', '');
+    $this->assertNoFieldChecked('data[greyscale]');
 
     // Alter a few values and then submit.
     $this->drupalPostForm(
@@ -130,6 +131,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
         'data[image_type]' => 'jpg',
         'data[delay]' => '250',
         'data[css]' => 'body { font-weight: 900; }',
+        'data[greyscale]' => TRUE,
       ],
       t('Add capture utility')
     );
@@ -143,6 +145,7 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertFieldByName('data[image_type]', 'jpg');
     $this->assertFieldByName('data[delay]', '250');
     $this->assertFieldByName('data[css]', 'body { font-weight: 900; }');
+    $this->assertFieldChecked('data[greyscale]');
 
     // Attempt to image type.
     $this->drupalPostForm(

--- a/tests/src/Functional/WebPageArchiveSettingsTest.php
+++ b/tests/src/Functional/WebPageArchiveSettingsTest.php
@@ -163,6 +163,7 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('wpa_screenshot_capture[defaults][delay]', 0);
     $this->assertFieldByName('wpa_screenshot_capture[defaults][image_type]', 'png');
     $this->assertFieldByName('wpa_screenshot_capture[defaults][width]', 1280);
+    $this->assertFieldByName('wpa_screenshot_capture[defaults][css]', '');
     $this->assertFieldByName('wpa_screenshot_capture[system][phantomjs_path]', '');
     $this->assertFieldByName('wpa_screenshot_capture[system][magick_path]', '');
     $this->assertFieldByName('wpa_screenshot_capture[system][magick_color]', '#ccc000');

--- a/tests/src/Functional/WebPageArchiveSettingsTest.php
+++ b/tests/src/Functional/WebPageArchiveSettingsTest.php
@@ -164,6 +164,7 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('wpa_screenshot_capture[defaults][image_type]', 'png');
     $this->assertFieldByName('wpa_screenshot_capture[defaults][width]', 1280);
     $this->assertFieldByName('wpa_screenshot_capture[defaults][css]', '');
+    $this->assertNoFieldChecked('wpa_screenshot_capture[defaults][greyscale]');
     $this->assertFieldByName('wpa_screenshot_capture[system][phantomjs_path]', '');
     $this->assertFieldByName('wpa_screenshot_capture[system][magick_path]', '');
     $this->assertFieldByName('wpa_screenshot_capture[system][magick_color]', '#ccc000');

--- a/tests/src/Functional/fixtures/config-import-with-null-uuid.yml
+++ b/tests/src/Functional/fixtures/config-import-with-null-uuid.yml
@@ -31,4 +31,5 @@ capture_utilities:
       image_type: jpg
       delay: 1000
       css: 'body { font-size: 30px; }'
+      greyscale: true
 run_entity: null

--- a/tests/src/Functional/fixtures/config-import-with-null-uuid.yml
+++ b/tests/src/Functional/fixtures/config-import-with-null-uuid.yml
@@ -30,4 +30,5 @@ capture_utilities:
       width: 1500
       image_type: jpg
       delay: 1000
+      css: 'body { font-size: 30px; }'
 run_entity: null

--- a/tests/src/Functional/fixtures/config-import-with-uuid.yml
+++ b/tests/src/Functional/fixtures/config-import-with-uuid.yml
@@ -32,4 +32,5 @@ capture_utilities:
       image_type: jpg
       delay: 1000
       css: ''
+      greyscale: false
 run_entity: 1915f871-7e08-4d53-9139-dc86b0d8e5a0

--- a/tests/src/Functional/fixtures/config-import-with-uuid.yml
+++ b/tests/src/Functional/fixtures/config-import-with-uuid.yml
@@ -31,4 +31,5 @@ capture_utilities:
       background_color: '#abc123'
       image_type: jpg
       delay: 1000
+      css: ''
 run_entity: 1915f871-7e08-4d53-9139-dc86b0d8e5a0


### PR DESCRIPTION
**Drupal.org Issues:** 
- Injecting CSS: https://www.drupal.org/project/web_page_archive/issues/3011372
- Adding greyscale: https://www.drupal.org/project/web_page_archive/issues/2922939

This PR adds a `CSS` field to the screenshot capture utility when using Chrome. 

_Important note: This requires `spatie/browsershot:3.26.0` or greater. So existing users will need to ensure they update to get the latest functionality._ 

For example if I add this CSS:

```css
.rackspace-main-site-eyebrow  { display: none; }
.footer  { display: none; }
.basement-container { display: none; }
```

I get this on https://www.rackspace.com: 
![image](https://user-images.githubusercontent.com/5263371/47978025-f6737e80-e080-11e8-8272-16c4936ca443.png)

Additionally, given the similar nature of the work, I've gone ahead and added a configurable greyscale option to this capture utility, which provides some data storage potential.

This screenshot shows two different runs, one in greyscale and one not.  There's about a 33% file size saving here (although admittedly a small dataset): 
![image](https://user-images.githubusercontent.com/5263371/47979827-97b30280-e08a-11e8-8036-28cdf2c05b76.png)

And captures look something like this: 
![image](https://user-images.githubusercontent.com/5263371/47979951-2031a300-e08b-11e8-9419-a10c8be04b85.png)
