### PR TITLE
Issue #3011599 by WidgetsBurritos: PHP 7.2 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ language: php
 sudo: false
 
 php:
-  - 7
+  - 7.0
+  - 7.1
+  - 7.2
 
 cache:
   directories:
@@ -97,7 +99,7 @@ mysql:
 
 before_install:
   - composer self-update
-  - composer global require "lionsad/drupal_ti:dev-master#019dc85b6de24455e11492e63364c2a9f193c84c" "drupal/coder:8.2.*" "sensiolabs/security-checker:*"
+  - composer global require "lionsad/drupal_ti:dev-master#019dc85b6de24455e11492e63364c2a9f193c84c" "symfony/yaml:2.*" "drupal/coder:8.2.*" "sensiolabs/security-checker:*"
   - drupal-ti before_install
 
 install:

--- a/src/Plugin/CompareResponse/TextDiffTrait.php
+++ b/src/Plugin/CompareResponse/TextDiffTrait.php
@@ -48,7 +48,7 @@ trait TextDiffTrait {
     $total_ct = 0;
     foreach ($diff_edits as $diff_edit) {
       if (isset($counts[$diff_edit->type])) {
-        $lines = max(count($diff_edit->orig), count($diff_edit->closing));
+        $lines = max(count((array) $diff_edit->orig), count((array) $diff_edit->closing));
         $changes += $counts[$diff_edit->type] * $lines;
         $total_ct += $lines;
       }


### PR DESCRIPTION
**Drupal.org Issue:** https://www.drupal.org/project/web_page_archive/issues/3011599

This PR updates Travis to check PHP 7.0, 7.1 and 7.2. 

Additionally, it fixes a minor PHP 7.2 warning as stated here: http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types

```
An E_WARNING will now be emitted when attempting to count() non-countable types (this includes the sizeof() alias function).
```

What is happening in the TextDiffTrait is that in some cases `$diff_edit->orig` and `$diff_edit->closing` return `FALSE`.  So by converting it to an array, we get a zero count, which is what we'd want there anyway. 