### PR TITLE
Issue #3042687 by WidgetsBurritos: Dispatch event upon job completion

### DIFF
--- a/src/Event/CaptureJobCompleteEvent.php
+++ b/src/Event/CaptureJobCompleteEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\web_page_archive\Event;
+
+use Drupal\web_page_archive\Entity\WebPageArchiveRunInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event that is fired when a capture job is finished.
+ */
+class CaptureJobCompleteEvent extends Event {
+
+  const EVENT_NAME = 'wpa_capture_complete';
+
+  /**
+   * The completed run entity.
+   *
+   * @var \Drupal\web_page_archive\Entity\WebPageArchiveRunInterface
+   */
+  public $runEntity;
+
+  /**
+   * Constructs the object.
+   *
+   * @param \Drupal\web_page_archive\Entity\WebPageArchiveRunInterface $run_entity
+   *   The run entity that just completed.
+   */
+  public function __construct(WebPageArchiveRunInterface $run_entity) {
+    $this->runEntity = $run_entity;
+  }
+
+}

--- a/src/Event/CompareJobCompleteEvent.php
+++ b/src/Event/CompareJobCompleteEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\web_page_archive\Event;
+
+use Drupal\web_page_archive\Entity\RunComparisonInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event that is fired when a compare job is finished.
+ */
+class CompareJobCompleteEvent extends Event {
+
+  const EVENT_NAME = 'wpa_compare_complete';
+
+  /**
+   * The completed comparison entity.
+   *
+   * @var \Drupal\web_page_archive\Entity\RunComparisonInterface
+   */
+  public $comparisonEntity;
+
+  /**
+   * Constructs the object.
+   *
+   * @param \Drupal\web_page_archive\Entity\RunComparisonInterface $comparison_entity
+   *   The comparison entity that just completed.
+   */
+  public function __construct(RunComparisonInterface $comparison_entity) {
+    $this->comparisonEntity = $comparison_entity;
+  }
+
+}

--- a/src/EventSubscriber/WebPageArchiveEventSubscriber.php
+++ b/src/EventSubscriber/WebPageArchiveEventSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\web_page_archive\EventSubscriber;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\web_page_archive\Event\CaptureJobCompleteEvent;
+use Drupal\web_page_archive\Event\CompareJobCompleteEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribes to the web page archive events.
+ */
+class WebPageArchiveEventSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return array
+   *   The event names to listen for, and the methods that should be executed.
+   */
+  public static function getSubscribedEvents() {
+    return [
+      CaptureJobCompleteEvent::EVENT_NAME => 'captureComplete',
+      CompareJobCompleteEvent::EVENT_NAME => 'compareComplete',
+    ];
+  }
+
+  /**
+   * React to a capture job completing.
+   *
+   * @param \Drupal\web_page_archive\Event\CaptureJobCompleteEvent $event
+   *   Capture job completion event.
+   */
+  public function captureComplete(CaptureJobCompleteEvent $event) {
+    \Drupal::messenger()->addStatus($this->t('The capture has been completed.'));
+  }
+
+  /**
+   * React to a compare job completing.
+   *
+   * @param \Drupal\web_page_archive\Event\CompareJobCompleteEvent $event
+   *   Compare job completion event.
+   */
+  public function compareComplete(CompareJobCompleteEvent $event) {
+    \Drupal::messenger()->addStatus($this->t('The comparison has been completed.'));
+  }
+
+}

--- a/tests/src/Kernel/Controller/RunComparisonControllerTest.php
+++ b/tests/src/Kernel/Controller/RunComparisonControllerTest.php
@@ -293,13 +293,22 @@ class RunComparisonControllerTest extends EntityStorageTestBase {
     $queue = $run_comparison->getQueue();
     $this->assertEquals(2, $queue->numberOfItems());
 
+    $context = [];
+
     // Attempt to process the next item in the queue.
-    $this->assertTrue($this->runComparisonController->batchProcess($run_comparison));
+    $this->assertTrue($this->runComparisonController->batchProcess($run_comparison, $context));
     $this->assertEquals(1, $queue->numberOfItems());
+    $this->assertEquals($run_comparison, $context['results']['entity']);
 
     // Attempt to process the next item in the queue.
     $this->assertTrue($this->runComparisonController->batchProcess($run_comparison));
     $this->assertEquals(0, $queue->numberOfItems());
+    $this->assertEquals($run_comparison, $context['results']['entity']);
+
+    // Simulate "batch finish" process.
+    $this->runComparisonController->batchFinished(TRUE, $context['results'], []);
+    $expected = ['status' => ['The comparison has been completed.']];
+    $this->assertEquals($expected, \Drupal::messenger()->all());
 
     $expected = [
       '1' => [

--- a/tests/src/Kernel/Controller/WebPageArchiveControllerTest.php
+++ b/tests/src/Kernel/Controller/WebPageArchiveControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Controller;
+
+use Drupal\Tests\web_page_archive\Kernel\EntityStorageTestBase;
+
+/**
+ * Tests the functionality of the web page archive controller.
+ *
+ * @group web_page_archive
+ */
+class WebPageArchiveControllerTest extends EntityStorageTestBase {
+
+  /**
+   * Tests WebPageArchiveController batch functionality.
+   */
+  public function testBatchFunctionality() {
+    $urls = [
+      'http://localhost',
+      'http://localhost/some-other-page',
+      'http://localhost/yet-another-page',
+    ];
+    $web_page_archive = $this->getWpaEntity('My run entity', $urls);
+    $web_page_archive->startNewRun();
+    $context = [];
+
+    // Confirm queue size matches URL list.
+    $queue = $web_page_archive->getQueue();
+    $this->assertEquals(3, $queue->numberOfItems());
+
+    // Attempt to process the next item in the queue.
+    $this->webPageArchiveController->batchProcess($web_page_archive, $context);
+    $this->assertEquals(2, $queue->numberOfItems());
+    $this->assertEquals($web_page_archive, $context['results']['entity']);
+
+    // Attempt to process the next item in the queue.
+    $this->webPageArchiveController->batchProcess($web_page_archive, $context);
+    $this->assertEquals(1, $queue->numberOfItems());
+    $this->assertEquals($web_page_archive, $context['results']['entity']);
+
+    // Attempt to process the next item in the queue.
+    $this->webPageArchiveController->batchProcess($web_page_archive, $context);
+    $this->assertEquals(0, $queue->numberOfItems());
+    $this->assertEquals($web_page_archive, $context['results']['entity']);
+
+    // Simulate "batch finish" process.
+    $this->webPageArchiveController->batchFinished(TRUE, $context['results'], []);
+    $expected = ['status' => ['The capture has been completed.']];
+    $this->assertEquals($expected, \Drupal::messenger()->all());
+
+  }
+
+}

--- a/tests/src/Kernel/EntityStorageTestBase.php
+++ b/tests/src/Kernel/EntityStorageTestBase.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\web_page_archive\Kernel;
 
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\web_page_archive\Controller\RunComparisonController;
+use Drupal\web_page_archive\Controller\WebPageArchiveController;
 use Drupal\web_page_archive\Entity\RunComparison;
 use Drupal\web_page_archive\Plugin\CompareResponseInterface;
 
@@ -19,6 +20,7 @@ abstract class EntityStorageTestBase extends EntityKernelTestBase {
   protected $runComparisonController;
   protected $runComparisonStorage;
   protected $runStorage;
+  protected $webPageArchiveController;
 
   /**
    * Modules to enable.
@@ -31,6 +33,7 @@ abstract class EntityStorageTestBase extends EntityKernelTestBase {
     'system',
     'views',
     'web_page_archive',
+    'wpa_skeleton_capture',
   ];
 
   /**
@@ -52,12 +55,40 @@ abstract class EntityStorageTestBase extends EntityKernelTestBase {
 
     // Setup services.
     $this->entityTypeManager = $this->container->get('entity_type.manager');
+    $this->wpaStorage = $this->entityTypeManager->getStorage('web_page_archive');
     $this->runStorage = $this->entityTypeManager->getStorage('web_page_archive_run');
     $this->runComparisonStorage = $this->entityTypeManager->getStorage('wpa_run_comparison');
     $this->fieldTypeManager = $this->container->get('plugin.manager.field.field_type');
     $this->fieldFormatterManager = $this->container->get('plugin.manager.field.formatter');
     $this->entityFieldManager = $this->container->get('entity_field.manager');
     $this->runComparisonController = RunComparisonController::create($this->container);
+    $this->webPageArchiveController = WebPageArchiveController::create($this->container);
+  }
+
+  /**
+   * Creates a web_page_archive entity.
+   */
+  protected function getWpaEntity($name, $urls = []) {
+    $run_entity = $this->getRunEntity($name, 1);
+    $data = [
+      'id' => md5($name),
+      'capture_utilities' => [
+        '3f6a4941-ce49-41cf-b779-dad4abaca300' => [
+          'uuid' => '3f6a4941-ce49-41cf-b779-dad4abaca300',
+          'id' => 'wpa_skeleton_capture',
+          'weight' => 1,
+        ],
+      ],
+      'name' => $name,
+      'urls' => implode(PHP_EOL, $urls),
+      'run_entity' => $run_entity->id(),
+      'use_robots' => FALSE,
+    ];
+
+    $entity = $this->wpaStorage->create($data);
+    $entity->save();
+
+    return $entity;
   }
 
   /**

--- a/web_page_archive.services.yml
+++ b/web_page_archive.services.yml
@@ -30,3 +30,7 @@ services:
     class: Drupal\web_page_archive\Plugin\CompareResponseFactory
     tags:
       - { name: factory }
+  web_page_archive.event_subscriber:
+    class: Drupal\web_page_archive\EventSubscriber\WebPageArchiveEventSubscriber
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
**Drupal.org Issue:** https://www.drupal.org/project/web_page_archive/issues/3042687

This PR causes Drupal to dispatch new custom events on completion of capture and comparison jobs.
I've relocated the job completion success message functionality into a separate event subscriber, as it allows us to test the functionality is working appropriately, and I've updated the tests accordingly. 