### PR TITLE
Issue #3072289 by WidgetsBurritos: Data Retention Functionality

### DIFF
--- a/config/install/views.view.web_page_archive_canonical.yml
+++ b/config/install/views.view.web_page_archive_canonical.yml
@@ -97,6 +97,73 @@ display:
           hide_empty: false
           default_field_elements: true
       fields:
+        retention_locked:
+          id: retention_locked
+          table: web_page_archive_run_revision
+          field: retention_locked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: 🔒
+            format_custom_false: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: web_page_archive_run
+          entity_field: retention_locked
+          plugin_id: field
         vid:
           id: vid
           table: web_page_archive_run_revision
@@ -173,8 +240,8 @@ display:
           label: Created
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ retention_locked}}{{ revision_created }}'
             make_link: false
             path: ''
             absolute: false
@@ -522,6 +589,55 @@ display:
           empty_zero: false
           hide_alter_empty: false
           plugin_id: custom
+        nothing_2:
+          id: nothing_2
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: 'Toggle Retention Lock'
+            make_link: true
+            path: 'admin/config/system/web-page-archive/runs/{{ vid }}/toggle-lock'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
         dropbutton:
           id: dropbutton
           table: views
@@ -573,6 +689,7 @@ display:
           fields:
             nothing: nothing
             nothing_1: nothing_1
+            nothing_2: nothing_2
             vid: '0'
             revision_created: '0'
             capture_utilities: '0'

--- a/config/install/web_page_archive.settings.yml
+++ b/config/install/web_page_archive.settings.yml
@@ -13,6 +13,8 @@ defaults:
   use_cron: true
   use_robots: true
   user_agent: WPA
+  retention_type: ''
+  retention_value: 365
 comparison:
   run1: null
   run2: null

--- a/config/schema/web_page_archive.schema.yml
+++ b/config/schema/web_page_archive.schema.yml
@@ -72,6 +72,12 @@ web_page_archive.settings:
         timeout:
           type: integer
           label: 'Timeout (ms)'
+        retention_type:
+          type: string
+          label: 'Data retention type'
+        retention_value:
+          type: integer
+          label: 'Data retention value'
 
 web_page_archive.web_page_archive.*:
   type: config_entity
@@ -106,6 +112,12 @@ web_page_archive.web_page_archive.*:
     timeout:
       type: integer
       label: 'Timeout (ms)'
+    retention_type:
+      type: string
+      label: 'Data retention type'
+    retention_value:
+      type: integer
+      label: 'Data retention value'
     capture_utilities:
       type: sequence
       sequence:

--- a/src/Controller/LockController.php
+++ b/src/Controller/LockController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\web_page_archive\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Class WebPageArchiveController.
+ *
+ * @package Drupal\web_page_archive\Controller
+ */
+class LockController extends ControllerBase {
+
+  /**
+   * Toggles the retention lock setting for the specified run.
+   */
+  public function toggleRetentionLock($web_page_archive_run_revision) {
+    $locked = $web_page_archive_run_revision->getRetentionLocked();
+    $web_page_archive_run_revision->setRetentionLocked(!$locked);
+    $web_page_archive_run_revision->save();
+    $wpa = $web_page_archive_run_revision->getConfigEntity();
+    return $this->redirect('entity.web_page_archive.canonical', ['web_page_archive' => $wpa->id()]);
+  }
+
+}

--- a/src/Cron/CronRunner.php
+++ b/src/Cron/CronRunner.php
@@ -83,6 +83,9 @@ class CronRunner {
    * Runs the cron runner on the config entity.
    */
   public function run($config_entity) {
+    // Remove old data.
+    $config_entity->processRetentionPlan();
+
     // Check if entity is configured to run on cron.
     $use_cron = $config_entity->getUseCron();
     if (!$use_cron) {

--- a/src/Entity/WebPageArchiveRun.php
+++ b/src/Entity/WebPageArchiveRun.php
@@ -44,6 +44,7 @@ use Drupal\web_page_archive\Controller\CleanupController;
  *     "queue_ct" = "queue_ct",
  *     "success_ct" = "success_ct",
  *     "capture_utilities" = "capture_utilities",
+ *     "retention_locked" = "retention_locked",
  *   },
  *   field_ui_base_route = "web_page_archive_run.settings"
  * )
@@ -231,6 +232,21 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
   }
 
   /**
+   * Indicates if run is "locked", which prevents removal via data retention.
+   */
+  public function getRetentionLocked() {
+    return (boolean) $this->get('retention_locked')->getString();
+  }
+
+  /**
+   * Sets the retention locked flag.
+   */
+  public function setRetentionLocked($flag) {
+    $this->set('retention_locked', $flag);
+    return $this;
+  }
+
+  /**
    * Marks a capture task complete.
    */
   public function markCaptureComplete($data) {
@@ -378,6 +394,12 @@ class WebPageArchiveRun extends RevisionableContentEntityBase implements WebPage
     $fields['success_ct'] = BaseFieldDefinition::create('wpa_default_integer')
       ->setLabel(t('Success count'))
       ->setDescription(t('Number of successfully completed in the queue.'))
+      ->setRevisionable(TRUE);
+
+    $fields['retention_locked'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Retention locked'))
+      ->setDescription(t('Indicates whether or not a run is protected from being removed by the retention policy.'))
+      ->setDefaultValue(FALSE)
       ->setRevisionable(TRUE);
 
     $fields['capture_size'] = BaseFieldDefinition::create('float')

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -258,6 +258,31 @@ class SettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('defaults.timeout'),
     ];
 
+    $form['defaults']['retention_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Data retention type'),
+      '#description' => $this->t('Determines the data retention policies for a job.'),
+      '#options' => [
+        '' => $this->t('Keep all revisions'),
+        'revisions' => $this->t('Keep last <em>X</em> revisions'),
+        'days' => $this->t('Keep revisions from last <em>X</em> days'),
+      ],
+      '#default_value' => $config->get('defaults.retention_type'),
+    ];
+
+    $form['defaults']['retention_value'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Data retention value'),
+      '#description' => $this->t('Amount of revisions/days to keep.'),
+      '#default_value' => $config->get('defaults.retention_value'),
+      '#states' => [
+        'visible' => [
+          ['select[name="defaults[retention_type]"]' => ['value' => 'revisions']],
+          ['select[name="defaults[retention_type]"]' => ['value' => 'days']],
+        ],
+      ],
+    ];
+
     $form['defaults']['url_type'] = [
       '#type' => 'select',
       '#title' => $this->t('Default Capture Type'),

--- a/src/Form/WebPageArchiveFormBase.php
+++ b/src/Form/WebPageArchiveFormBase.php
@@ -169,6 +169,35 @@ abstract class WebPageArchiveFormBase extends EntityForm {
       '#default_value' => !$this->entity->isNew() ? $this->entity->getUserAgent() : $config->get('defaults.user_agent'),
     ];
 
+    $form['retention_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Data retention type'),
+      '#description' => $this->t('Determines the data retention policy for a job. <br><em>Warning: Changing this on existing jobs may result in data loss.</em>'),
+      '#options' => [
+        '' => $this->t('Keep all revisions'),
+        'revisions' => $this->t('Keep last <em>X</em> revisions'),
+        'days' => $this->t('Keep revisions from last <em>X</em> days'),
+      ],
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getRetentionType() : $config->get('defaults.retention_type'),
+    ];
+
+    $form['retention_value'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Data retention value'),
+      '#description' => $this->t('Amount of revisions/days to keep.'),
+      '#default_value' => !$this->entity->isNew() ? $this->entity->getRetentionValue() : $config->get('defaults.retention_value'),
+      '#states' => [
+        'visible' => [
+          ['select[name="retention_type"]' => ['value' => 'revisions']],
+          ['select[name="retention_type"]' => ['value' => 'days']],
+        ],
+        'required' => [
+          ['select[name="retention_type"]' => ['value' => 'revisions']],
+          ['select[name="retention_type"]' => ['value' => 'days']],
+        ],
+      ],
+    ];
+
     $form['urls'] = [
       '#type' => 'textarea',
       '#title' => $this->t('URLs to Capture'),

--- a/tests/src/Functional/WebPageArchiveEntityTest.php
+++ b/tests/src/Functional/WebPageArchiveEntityTest.php
@@ -510,8 +510,15 @@ class WebPageArchiveEntityTest extends BrowserTestBase {
     $this->assertTrue(file_exists($file_paths[0]));
     $this->assertTrue(file_exists($file_paths[1]));
 
-    // Attempt to download captures.
+    // Attempt to toggle run locks.
     $this->drupalGet('admin/config/system/web-page-archive/jobs/localhost');
+    $assert->pageTextNotContains('🔒');
+    $this->clickLink('Toggle Retention Lock');
+    $assert->pageTextContains('🔒');
+    $this->clickLink('Toggle Retention Lock');
+    $assert->pageTextNotContains('🔒');
+
+    // Attempt to download captures.
     $this->clickLink('Download Run');
     $assert->pageTextContains('You can download all images from the specified run as a *.zip file.');
     $this->drupalPostForm(NULL, [], t('Download Run'));

--- a/tests/src/Functional/WebPageArchiveSettingsTest.php
+++ b/tests/src/Functional/WebPageArchiveSettingsTest.php
@@ -70,6 +70,7 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('defaults[user_agent]', 'WPA');
     $this->assertFieldByName('defaults[use_cron]', 1);
     $this->assertFieldByName('defaults[use_robots]', 1);
+    $this->assertFieldByName('defaults[retention_type]', '');
     $this->assertFieldByName('comparison[run1]', '');
     $this->assertFieldByName('comparison[run2]', '');
     $this->assertFieldByName('comparison[strip_type]', '');
@@ -92,6 +93,8 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
         'defaults[url_type]' => 'sitemap',
         'defaults[user_agent]' => 'NinjaBot',
         'defaults[use_robots]' => 0,
+        'defaults[retention_type]' => 'days',
+        'defaults[retention_value]' => 142,
         'comparison[run1]' => 1,
         'comparison[run2]' => 1,
         'comparison[strip_type]' => 'string',
@@ -114,6 +117,8 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('defaults[url_type]', 'sitemap');
     $this->assertFieldByName('defaults[user_agent]', 'NinjaBot');
     $this->assertFieldByName('defaults[use_robots]', 0);
+    $this->assertFieldByName('defaults[retention_type]', 'days');
+    $this->assertFieldByName('defaults[retention_value]', 142);
     $this->assertFieldByName('comparison[run1]', '1');
     $this->assertFieldByName('comparison[run2]', '1');
     $this->assertFieldByName('comparison[strip_type]', 'string');
@@ -130,6 +135,8 @@ class WebPageArchiveSettingsTest extends BrowserTestBase {
     $this->assertFieldByName('url_type', 'sitemap');
     $this->assertFieldByName('user_agent', 'NinjaBot');
     $this->assertFieldByName('use_robots', 0);
+    $this->assertFieldByName('retention_type', 'days');
+    $this->assertFieldByName('retention_value', 142);
 
     // Ensure default values made it into the compare form.
     $this->drupalGet('admin/config/system/web-page-archive/compare');

--- a/tests/src/Kernel/Controller/CleanupControllerTest.php
+++ b/tests/src/Kernel/Controller/CleanupControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Drupal\Tests\web_page_archive\Kernel\Controller;
+
+use Drupal\Tests\web_page_archive\Kernel\EntityStorageTestBase;
+
+/**
+ * Tests the functionality of the cleanup controller.
+ *
+ * @group web_page_archive
+ */
+class CleanupControllerTest extends EntityStorageTestBase {
+
+  /**
+   * Tests RunComparisonController::deleteOldRevisionsByDays().
+   */
+  public function testDeleteOldRevisionsByDays() {
+    // Start 5 days ago.
+    $start_time = $this->container->get('datetime.time')->getCurrentTime() - 5 * 86400;
+    $urls = ['https://www.homestarrunner.com'];
+
+    // Create a config entity with revisions incrementing by 24 hours.
+    $web_page_archive = $this->getWpaEntity('Some job', $urls, 5, $start_time, 86400);
+
+    // Set our retention settings to 3 days.
+    $web_page_archive->set('retention_type', 'days');
+    $web_page_archive->set('retention_value', '3');
+    $web_page_archive->save();
+
+    // Confirm 5 additional revisions were created (i.e. 6 total).
+    $revision_ids = $web_page_archive->getRevisionIds();
+    $this->assertEquals(6, count($revision_ids));
+
+    // Lock a revision that would get removed otherwise.
+    $locked_run = $this->runStorage->loadRevision($revision_ids[1]);
+    $locked_run->setRetentionLocked(TRUE);
+    $locked_run->save();
+
+    // Lock another revision that would not get removed.
+    $locked_run = $this->runStorage->loadRevision($revision_ids[5]);
+    $locked_run->setRetentionLocked(TRUE);
+    $locked_run->save();
+
+    // Process the retention plan.
+    $web_page_archive->processRetentionPlan();
+
+    // There were originally 6 revisions:
+    // - 5 days ago
+    // - 4 days ago (locked)
+    // - 3 days ago
+    // - 2 days ago
+    // - 1 days ago (locked)
+    // - 0 days ago
+    // Any revisions 3 days or older should be removed so 6-3=3.
+    // However one of those revisions is locked, so we can only remove 2.
+    // Thus the expectation is 6-2=4.
+    $revision_ids = $web_page_archive->getRevisionIds();
+    $this->assertEquals(4, count($revision_ids));
+  }
+
+  /**
+   * Tests RunComparisonController::deleteOldRevisionsByRevisions().
+   */
+  public function testDeleteOldRevisionsByRevisions() {
+    // Start 5 days ago.
+    $start_time = $this->container->get('datetime.time')->getCurrentTime() - 3 * 86400;
+    $urls = ['https://www.homestarrunner.com'];
+
+    // Create a config entity with revisions incrementing by 12 hours.
+    $web_page_archive = $this->getWpaEntity('Some job', $urls, 5, $start_time, 43200);
+
+    // Set our retention settings to 5 revisions.
+    $web_page_archive->set('retention_type', 'revisions');
+    $web_page_archive->set('retention_value', '3');
+    $web_page_archive->save();
+
+    // Confirm 10 additional revisions were created (i.e. 11 total).
+    $revision_ids = $web_page_archive->getRevisionIds();
+    $this->assertEquals(6, count($revision_ids));
+
+    // Lock a revision that would get removed otherwise.
+    $locked_run = $this->runStorage->loadRevision($revision_ids[1]);
+    $locked_run->setRetentionLocked(TRUE);
+    $locked_run->save();
+
+    // Lock another revision that would not get removed.
+    $locked_run = $this->runStorage->loadRevision($revision_ids[5]);
+    $locked_run->setRetentionLocked(TRUE);
+    $locked_run->save();
+
+    // Process the retention plan.
+    $web_page_archive->processRetentionPlan();
+
+    // There were originally 6 revisions:
+    // - 60 hours ago
+    // - 48 hours ago (locked)
+    // - 36 hours ago
+    // - 24 hours ago
+    // - 12 hours ago (locked)
+    // - 0 hours ago
+    // We're only interested in the 3 most recent revisions.
+    // But the revision from 48 hours ago is locked, so it takes place of the
+    // revision from 24 hours ago.
+    $expected = [
+      $revision_ids[1],
+      $revision_ids[4],
+      $revision_ids[5],
+    ];
+    $revision_ids = $web_page_archive->getRevisionIds();
+    $this->assertEquals(3, count($revision_ids));
+
+    $this->assertEquals($expected, $revision_ids);
+  }
+
+  /**
+   * Tests that nothing is removed if using default settings.
+   */
+  public function testDefaultSettingsDontDeleteAnything() {
+    // Start 5 days ago.
+    $start_time = $this->container->get('datetime.time')->getCurrentTime() - 3 * 86400;
+    $urls = ['https://www.homestarrunner.com'];
+
+    // Create a config entity with revisions incrementing by 12 hours.
+    $web_page_archive = $this->getWpaEntity('Some job', $urls, 5, $start_time, 43200);
+
+    // Confirm 10 additional revisions were created (i.e. 11 total).
+    $revision_ids = $web_page_archive->getRevisionIds();
+    $this->assertEquals(6, count($revision_ids));
+
+    // Process the retention plan.
+    $web_page_archive->processRetentionPlan();
+
+    $revision_ids = $web_page_archive->getRevisionIds();
+    $this->assertEquals(6, count($revision_ids));
+  }
+
+}

--- a/web_page_archive.install
+++ b/web_page_archive.install
@@ -689,3 +689,17 @@ function web_page_archive_update_8202() {
     }
   }
 }
+
+/**
+ * Add 'retention_locked' to web page archive run entities.
+ */
+function web_page_archive_update_8203() {
+  $storage_definition = BaseFieldDefinition::create('boolean')
+    ->setLabel(t('Retention locked'))
+    ->setDescription(t('Indicates whether or not a run is protected from being removed by the retention policy.'))
+    ->setRevisionable(TRUE)
+    ->setDefaultValue(FALSE);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('retention_locked', 'web_page_archive_run', 'web_page_archive_run', $storage_definition);
+}

--- a/web_page_archive.post_update.php
+++ b/web_page_archive.post_update.php
@@ -59,6 +59,31 @@ function web_page_archive_post_update_2956141_reimport_canonical_view() {
 }
 
 /**
+ * Issue 3072289: Reimports the web page archive canonical view.
+ */
+function web_page_archive_post_update_3072289_reimport_canonical_view() {
+  $views = ['views.view.web_page_archive_canonical'];
+  _web_page_archive_reimport_views($views);
+}
+
+/**
+ * Sets data retention default settings for all existing config entities.
+ */
+function web_page_archive_post_update_3072289_set_default_retention_values() {
+  $config_factory = \Drupal::service('config.factory');
+  $config_prefix = 'web_page_archive.web_page_archive';
+  $keys = $config_factory->listAll($config_prefix);
+
+  foreach ($keys as $key) {
+    $wpa_config = $config_factory->getEditable($key);
+    // Defaulting to FALSE preserves existing functionality.
+    $wpa_config->set('retention_type', '');
+    $wpa_config->set('retention_value', '365');
+    $wpa_config->save();
+  }
+}
+
+/**
  * Helper function to reimport existing views from the install directory.
  */
 function _web_page_archive_reimport_views($views) {

--- a/web_page_archive.routing.yml
+++ b/web_page_archive.routing.yml
@@ -143,6 +143,17 @@ entity.web_page_archive.run_download:
   requirements:
     _permission: 'view web page archive results'
 
+entity.web_page_archive.run_toggle_lock:
+  path: 'admin/config/system/web-page-archive/runs/{web_page_archive_run_revision}/toggle-lock'
+  defaults:
+    _controller: '\Drupal\web_page_archive\Controller\LockController::toggleRetentionLock'
+  options:
+    parameters:
+      web_page_archive_run_revision:
+        type: web_page_archive_run_revision
+  requirements:
+    _permission: 'administer web page archive'
+
 entity.web_page_archive.modal:
   path: 'admin/config/system/web-page-archive/modal/{web_page_archive_run_revision}/{delta}'
   defaults:


### PR DESCRIPTION
**Drupal.org Issue:** https://www.drupal.org/project/web_page_archive/issues/3072289

**Config entity changes:**
- Added `retention_type` and `retention_value` fields to the config entities (with getter methods)
    - Corresponding changes were made to the config entity edit form, default settings form and schemas.
    - Users can now select the following data retention options:
        - Keep all revisions (default)
        - Keep last <em>X</em> revisions
        - Keep revisions from last <em>X</em> days
    - <em>X</em> is customizable
- Added `WebPageArchive::getRevisionIds()` which provides a shorthand means of getting all revision ids (in a sorted order), for a particular config entity. 
- Added `WebPageArchive::processRetentionPlan()` which processes the retention plan based on the current settings for the config entity. 

**Content entity changes:**
- Added `retention_locked` field (and corresponding getter/setter methods)
    - Defaults to `FALSE`

**Controllers/routing changes:**
- Added `CleanupController::deleteOldRevisionsByDays` and `CleanupController::deleteOldRevisionsByRevisions()` to remove old revisions by the various methods
- Added `LockController` to toggle the data retention lock for a particular run. 
    - This controller corresponds to the `entity.web_page_archive.run_toggle_lock` route, which is located here: `admin/config/system/web-page-archive/runs/{web_page_archive_run_revision}/toggle-lock`

**Cron changes:**
- Runs `WebPageArchive::processRetentionPlan()` for each config entity on cron. 

**Update/post-update hooks:**
- `web_page_archive_update_8203()` - Adds the `retention_locked` field to run content entities.
- `web_page_archive_post_update_3072289_reimport_canonical_view()` - forces the `views.view.web_page_archive_canonical` view to get reimported.
- `web_page_archive_post_update_3072289_set_default_retention_values()` - sets the default retention values for all existing config entities

**View changes:**
- Updated the canonical view to indicate whether or not an individual run is locked or not, by adding the 🔒symbol.

**Test changes:**
- Changed `EntityStorageTestBase`
    - Modified `EntityStorageTestBase::getWpaEntity()` to allow for variability in revision counts, start time, and time incrementing factors for revisions (i.e.  If one entity is created at time X, the next one is created at time X + Incrementing Factor), and so on. 
    - Also modified `EntityStorageTestBase::getWpaEntity()`to reference the UUID for the run entity instead of the integer id, as that's how WPA actually works and then mapped the config entity back to the run entity.
    - Modified `EntityStorageTestBase::getRunEntity()` to use the incrementing time factor specified above and defaults the `retention_locked` value as `FALSE`.
- Created `CleanupControllerTest` which uses `EntityStorageTestBase` and tests the `CleanupController` functionality.
  - This test covers all three data retention types, including those with locked runs. 

